### PR TITLE
URL-safe Base64 for use in routes and params

### DIFF
--- a/lib/global_id/global_id.rb
+++ b/lib/global_id/global_id.rb
@@ -19,7 +19,13 @@ class GlobalID
     def parse(gid)
       gid.is_a?(self) ? gid : new(gid)
     rescue URI::Error
-      nil
+      parse_encoded_gid(gid)
+    end
+
+    def parse_encoded_gid(gid)
+      padding_chars = 4 - gid.length % 4
+      gid += '=' * padding_chars
+      new(Base64.urlsafe_decode64(gid)) rescue nil
     end
   end
 
@@ -43,6 +49,10 @@ class GlobalID
 
   def to_s
     @uri.to_s
+  end
+
+  def to_param
+    Base64.urlsafe_encode64(to_s).sub(/=+$/, '')
   end
 
   private

--- a/lib/global_id/signed_global_id.rb
+++ b/lib/global_id/signed_global_id.rb
@@ -15,4 +15,5 @@ class SignedGlobalID < GlobalID
   def to_s
     @sgid ||= self.class.verifier.generate(super)
   end
+  alias to_param to_s
 end

--- a/test/cases/global_id_test.rb
+++ b/test/cases/global_id_test.rb
@@ -30,6 +30,23 @@ class URIValidationTest < ActiveSupport::TestCase
   end
 end
 
+class GlobalIDParamEncodedTest < ActiveSupport::TestCase
+  setup do
+    model = Person.new('id')
+    @gid = GlobalID.create(model)
+  end
+
+  test 'parsing' do
+    assert_equal GlobalID.parse(@gid.to_param), @gid
+  end
+
+  test 'finding' do
+    found = GlobalID.find(@gid.to_param)
+    assert_kind_of @gid.model_class, found
+    assert_equal @gid.model_id, found.id
+  end
+end
+
 class GlobalIDCreationTest < ActiveSupport::TestCase
   setup do
     @uuid = '7ef9b614-353c-43a1-a203-ab2307851990'
@@ -44,6 +61,13 @@ class GlobalIDCreationTest < ActiveSupport::TestCase
     assert_equal "gid://bcx/Person/#{@uuid}", @person_uuid_gid.to_s
     assert_equal 'gid://bcx/Person::Child/4', @person_namespaced_gid.to_s
     assert_equal 'gid://bcx/PersonModel/1', @person_model_gid.to_s
+  end
+
+  test 'as param' do
+    assert_equal 'Z2lkOi8vYmN4L1BlcnNvbi81', @person_gid.to_param
+    assert_equal 'Z2lkOi8vYmN4L1BlcnNvbi83ZWY5YjYxNC0zNTNjLTQzYTEtYTIwMy1hYjIzMDc4NTE5OTA', @person_uuid_gid.to_param
+    assert_equal 'Z2lkOi8vYmN4L1BlcnNvbjo6Q2hpbGQvNA', @person_namespaced_gid.to_param
+    assert_equal 'Z2lkOi8vYmN4L1BlcnNvbk1vZGVsLzE', @person_model_gid.to_param
   end
 
   test 'as URI' do

--- a/test/cases/global_locator_test.rb
+++ b/test/cases/global_locator_test.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 class GlobalLocatorTest < ActiveSupport::TestCase
   setup do
-    model = Person.new
+    model = Person.new('id')
     @gid  = model.gid
     @sgid = model.sgid
   end
@@ -29,6 +29,12 @@ class GlobalLocatorTest < ActiveSupport::TestCase
     found = GlobalID::Locator.locate_signed(@sgid.to_s)
     assert_kind_of @sgid.model_class, found
     assert_equal @sgid.model_id, found.id
+  end
+
+  test 'by to_param encoding' do
+    found = GlobalID::Locator.locate(@gid.to_param)
+    assert_kind_of @gid.model_class, found
+    assert_equal @gid.model_id, found.id
   end
 
   test 'by non-GID returns nil' do

--- a/test/cases/signed_global_id_test.rb
+++ b/test/cases/signed_global_id_test.rb
@@ -24,4 +24,8 @@ class SignedGlobalIDTest < ActiveSupport::TestCase
   test 'value equality with an unsigned id' do
     assert_equal GlobalID.create(Person.new(5)), SignedGlobalID.create(Person.new(5))
   end
+
+  test 'to param' do
+    assert_equal @person_sgid.to_s, @person_sgid.to_param
+  end
 end


### PR DESCRIPTION
Two questions:
1) I used `Base64.urlsafe_encode64` instead because that seemed to make sense, that ok?
2) Should it locate with a base64 encoded signed gid? If so, I can add another commit for that.
