### PR TITLE
Expiration for signed global ids.

### DIFF
--- a/lib/global_id/railtie.rb
+++ b/lib/global_id/railtie.rb
@@ -17,6 +17,9 @@ class GlobalID
       app.config.global_id.app ||= app.railtie_name.remove('_application').dasherize
       GlobalID.app = app.config.global_id.app
 
+      app.config.global_id.expires_in ||= 1.month
+      SignedGlobalID.expires_in = app.config.global_id.expires_in
+
       config.after_initialize do
         app.config.global_id.verifier ||= begin
           app.message_verifier(:signed_global_ids)


### PR DESCRIPTION
Adds #27.
##### `expires_in`

This change adds a class and instance level `expires_in` setting, which signed global ids use to assign an expiration date to itself.
The instance level option takes precedence to the class level option.

An application configuration point is provided to set the class level `expires_in`.
##### `expires_at`

An instance level option to provide an explicit expiration date is also added. This takes precedence to any of the `expires_in` options.
# 

Passing `nil` to either of the instance level expiration options turns off expiration checking. I.e. it creates a signed global id that won't expire.
