### PR TITLE
Passing nil expires_at turns off expiration checking.

### DIFF
--- a/lib/global_id/signed_global_id.rb
+++ b/lib/global_id/signed_global_id.rb
@@ -75,7 +75,7 @@ class SignedGlobalID < GlobalID
 
   private
     def pick_expiration(options)
-      return options[:expires_at] if options[:expires_at]
+      return options[:expires_at] if options.key?(:expires_at)
 
       if expires_in = options.fetch(:expires_in) { self.class.expires_in }
         expires_in.from_now

--- a/test/cases/signed_global_id_test.rb
+++ b/test/cases/signed_global_id_test.rb
@@ -169,11 +169,13 @@ class SignedGlobalIDExpirationTest < ActiveSupport::TestCase
     assert_not SignedGlobalID.parse(sgid.to_s)
   end
 
-  test 'passing nil expires_at' do
-    encoded_sgid = SignedGlobalID.new(@uri, expires_at: nil).to_s
+  test 'passing nil expires_at turns off expiration checking' do
+    with_expiration_in 1.hour do
+      encoded_sgid = SignedGlobalID.new(@uri, expires_at: nil).to_s
 
-    travel 4.hours
-    assert SignedGlobalID.parse(encoded_sgid)
+      travel 4.hours
+      assert SignedGlobalID.parse(encoded_sgid)
+    end
   end
 
   test 'passing expires_at overrides class level expires_in' do


### PR DESCRIPTION
In #29, I forgot to allow passing a `nil` `expires_at` to turn off expiration checking. Sorry about that.
