### PR TITLE
Deprecate `gid`/`sgid`/`global_id`/`signed_global_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Mix `GlobalID::Identification` in to any model with a #find(id) class method.
 Support is automatically included in Active Record.
 
 ```ruby
->> person_gid = Person.find(1).global_id
+>> person_gid = Person.find(1).to_global_id
 => #<GlobalID ...
 
 >> person_gid.uri

--- a/lib/global_id/identification.rb
+++ b/lib/global_id/identification.rb
@@ -1,17 +1,42 @@
 require 'active_support/concern'
+require 'active_support/deprecation'
 
 class GlobalID
   module Identification
     extend ActiveSupport::Concern
 
-    def global_id
+    def to_global_id
       @global_id ||= GlobalID.create(self)
     end
-    alias gid global_id
+    alias to_gid to_global_id
 
-    def signed_global_id(options = {})
+    def to_signed_global_id(options = {})
       @signed_global_id ||= SignedGlobalID.create(self, options)
     end
-    alias sgid signed_global_id
+    alias to_sgid to_signed_global_id
+
+    private
+      DEPRECATED_ALIASES = {
+        gid: :to_gid,
+        sgid: :to_sgid,
+        global_id: :to_global_id,
+        signed_global_id: :to_signed_global_id
+      }.freeze
+
+      def method_missing(name, *args, &block)
+        super
+      rescue NoMethodError => e
+        if name == e.name && DEPRECATED_ALIASES.keys.include?(name)
+          new_name = DEPRECATED_ALIASES[name]
+          ActiveSupport::Deprecation.warn "`#{name}` is deprecate and will be removed soon. Use `#{new_name}` instead."
+          public_send(new_name, *args)
+        else
+          raise
+        end
+      end
+
+      def respond_to_missing?(name, include_private = false)
+        DEPRECATED_ALIASES.keys.include?(name) || super
+      end
   end
 end

--- a/test/cases/global_identification_test.rb
+++ b/test/cases/global_identification_test.rb
@@ -6,17 +6,41 @@ class GlobalIdentificationTest < ActiveSupport::TestCase
   end
 
   test 'creates a Global ID from self' do
-    assert_equal GlobalID.create(@model), @model.global_id
-    assert_equal GlobalID.create(@model), @model.gid
+    assert_equal GlobalID.create(@model), @model.to_global_id
+    assert_equal GlobalID.create(@model), @model.to_gid
+
+    assert_deprecated { assert_equal GlobalID.create(@model), @model.global_id }
+    assert_deprecated { assert_equal GlobalID.create(@model), @model.gid }
   end
 
   test 'creates a signed Global ID from self' do
-    assert_equal SignedGlobalID.create(@model), @model.signed_global_id
-    assert_equal SignedGlobalID.create(@model), @model.sgid
+    assert_equal SignedGlobalID.create(@model), @model.to_signed_global_id
+    assert_equal SignedGlobalID.create(@model), @model.to_sgid
+
+    assert_deprecated { assert_equal SignedGlobalID.create(@model), @model.signed_global_id }
+    assert_deprecated { assert_equal SignedGlobalID.create(@model), @model.sgid }
   end
 
   test 'creates a signed Global ID with purpose ' do
-    assert_equal SignedGlobalID.create(@model, for: 'login'), @model.signed_global_id(for: 'login')
-    assert_equal SignedGlobalID.create(@model, for: 'login'), @model.sgid(for: 'login')
+    assert_equal SignedGlobalID.create(@model, for: 'login'), @model.to_signed_global_id(for: 'login')
+    assert_equal SignedGlobalID.create(@model, for: 'login'), @model.to_sgid(for: 'login')
+
+    assert_deprecated { assert_equal SignedGlobalID.create(@model, for: 'login'), @model.signed_global_id(for: 'login') }
+    assert_deprecated { assert_equal SignedGlobalID.create(@model, for: 'login'), @model.sgid(for: 'login') }
+  end
+
+  test 'deprecated aliases give way to methods defined on the class' do
+    user = UnixUser.new(1)
+
+    assert_not_deprecated { assert_equal 'group ID', user.gid }
+    assert_not_deprecated { assert_equal 'set group ID', user.sgid }
+    assert_not_deprecated { assert_equal 'global_id', user.global_id }
+
+    assert_deprecated { assert_equal SignedGlobalID.create(user), user.signed_global_id }
+
+    assert_respond_to user, :gid
+    assert_respond_to user, :sgid
+    assert_respond_to user, :global_id
+    assert_respond_to user, :signed_global_id
   end
 end

--- a/test/cases/global_locator_test.rb
+++ b/test/cases/global_locator_test.rb
@@ -3,8 +3,8 @@ require 'helper'
 class GlobalLocatorTest < ActiveSupport::TestCase
   setup do
     model = Person.new('id')
-    @gid  = model.gid
-    @sgid = model.sgid
+    @gid  = model.to_gid
+    @sgid = model.to_sgid
   end
 
   test 'by GID' do
@@ -21,7 +21,7 @@ class GlobalLocatorTest < ActiveSupport::TestCase
 
   test 'by GID with only: restriction with match subclass' do
     instance = Person::Child.new
-    gid = instance.gid
+    gid = instance.to_gid
     found = GlobalID::Locator.locate(gid, only: Person)
     assert_kind_of gid.model_class, found
     assert_equal gid.model_id, found.id
@@ -69,7 +69,7 @@ class GlobalLocatorTest < ActiveSupport::TestCase
 
   test 'by SGID with only: restriction with match subclass' do
     instance = Person::Child.new
-    sgid = instance.sgid
+    sgid = instance.to_sgid
     found = GlobalID::Locator.locate_signed(sgid, only: Person)
     assert_kind_of sgid.model_class, found
     assert_equal sgid.model_id, found.id
@@ -176,7 +176,7 @@ class GlobalLocatorTest < ActiveSupport::TestCase
 
   test "by valid purpose returns right model" do
     instance = Person.new
-    login_sgid = instance.signed_global_id(for: 'login')
+    login_sgid = instance.to_sgid(for: 'login')
 
     found = GlobalID::Locator.locate_signed(login_sgid.to_s, for: 'login')
     assert_kind_of login_sgid.model_class, found
@@ -185,7 +185,7 @@ class GlobalLocatorTest < ActiveSupport::TestCase
 
   test "by invalid purpose returns nil" do
     instance = Person.new
-    login_sgid = instance.signed_global_id(for: 'login')
+    login_sgid = instance.to_sgid(for: 'login')
 
     assert_nil GlobalID::Locator.locate_signed(login_sgid.to_s, for: 'like_button')
   end

--- a/test/cases/signed_global_id_test.rb
+++ b/test/cases/signed_global_id_test.rb
@@ -61,7 +61,7 @@ class SignedGlobalIDVerifierTest < ActiveSupport::TestCase
 
   test 'new accepts a :verifier' do
     with_default_verifier nil do
-      expected = SignedGlobalID.new(Person.new(5).gid.uri, verifier: VERIFIER)
+      expected = SignedGlobalID.new(Person.new(5).to_gid.uri, verifier: VERIFIER)
       assert_equal @person_sgid, expected
     end
   end
@@ -97,7 +97,7 @@ class SignedGlobalIDPurposeTest < ActiveSupport::TestCase
   end
 
   test 'new accepts a :for' do
-    expected = SignedGlobalID.new(Person.new(5).gid.uri, for: 'login')
+    expected = SignedGlobalID.new(Person.new(5).to_gid.uri, for: 'login')
     assert_equal @login_sgid, expected
   end
 
@@ -120,7 +120,7 @@ end
 
 class SignedGlobalIDExpirationTest < ActiveSupport::TestCase
   setup do
-    @uri = Person.new(5).gid.uri
+    @uri = Person.new(5).to_gid.uri
   end
 
   test 'expires_in defaults to class level expiration' do

--- a/test/models/person.rb
+++ b/test/models/person.rb
@@ -17,3 +17,31 @@ class Person
 end
 
 class Person::Child < Person; end
+
+module UnixGroupMember
+  def gid
+    'group ID'
+  end
+end
+
+class UnixUser < Person
+  include UnixGroupMember
+
+  def sgid
+    'set group ID'
+  end
+
+  # Some version of Active Record uses method missing to define attribute
+  # methods
+  def method_missing(name, *args, &block)
+    if name == :global_id
+      'global_id'
+    else
+      super
+    end
+  end
+
+  def respond_to_missing?(name, include_private = false)
+    (name == :global_id) || super
+  end
+end


### PR DESCRIPTION
Did a quick spike to see how we can gracefully handle the rename, but it took more code than I thought, so I am not sure if it's worth the effort. However I suppose we will cut a 1.0 release to go out with 4.2.0.final, so not like this code is staying for a long time anyway.

Feel free to reject this and just rename it if you don't think it's worth the trouble. This is still < 1.0 so I suppose it's fair game either way.

Closes #34
