### PR TITLE
Test against activesupport 4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /.ruby-version
-/Gemfile.lock
+*.lock

--- a/gemfiles/Gemfile-activesupport-4.0
+++ b/gemfiles/Gemfile-activesupport-4.0
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activesupport', '~> 4.0'
+gem 'activemodel'
+gem 'railties'

--- a/globalid.gemspec
+++ b/globalid.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   # TODO: may relax this dependency further
-  s.add_runtime_dependency 'activesupport', '>= 4.1.0'
+  s.add_runtime_dependency 'activesupport', '>= 4.0.0'
 
   s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Hi, this gem would be valuable for earlier versions of Rails (especially for an ActiveJob backport).  Added an additional Gemfile based on the structure of https://github.com/rails/protected_attributes.  All tests pass without any code changes, but looking at the `# TODO: may relax this dependency further` comment, it seems there may be some hesitation to do this.  Curious to hear your thoughts.  Thanks!
