### PR TITLE
Partially revert 4c933fb where `#to_s` was changed unintentionally.

### DIFF
--- a/lib/global_id/uri/gid.rb
+++ b/lib/global_id/uri/gid.rb
@@ -89,7 +89,7 @@ module URI
 
     def to_s
       # Implement #to_s to avoid no implicit conversion of nil into string when path is nil
-      "gid://#{app}#{path_query}"
+      "gid://#{app}/#{model_name}/#{model_id}"
     end
 
     protected


### PR DESCRIPTION
cc #44 
