### PR TITLE
Avoid using internal path_query method.

### DIFF
--- a/lib/global_id/uri/gid.rb
+++ b/lib/global_id/uri/gid.rb
@@ -89,7 +89,7 @@ module URI
 
     def to_s
       # Implement #to_s to avoid no implicit conversion of nil into string when path is nil
-      "gid://#{app}#{path_query}"
+      "gid://#{app}#{path}#{'?' + query if query}"
     end
 
     protected


### PR DESCRIPTION
Fixes #49

`path_query` is an `URI::Generic` internal method, which has been removed in Ruby head.

cc @zzak @rafaelfranca
