### PR TITLE
Small documentation example fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ people shouldn't have indefinite access to, like a share link.
 >> GlobalID::Locator.locate_signed(expiring_sgid, for: 'sharing')
 => nil
 
->> explicit_expiring_sgid = SecretAgentMessage.find(5).to_sgid(expires_at: Date.today.midnight)
+>> explicit_expiring_sgid = SecretAgentMessage.find(5).to_sgid(expires_at: Date.tomorrow.midnight)
 => #<SignedGlobalID:0x008fde45df8937
 
 # After midnight...


### PR DESCRIPTION
`Date.today.midnight` will always return a time in the past; I think what you meant was "the next midnight", which is actually midnight tomorrow if you consider midnight the start of the day (as computer languages do.)