### PR TITLE
Update set_params hook for Ruby 2.2.

### DIFF
--- a/lib/global_id/uri/gid.rb
+++ b/lib/global_id/uri/gid.rb
@@ -98,6 +98,13 @@ module URI
         super
       end
 
+      # Ruby 2.2 uses #query= instead of #set_query
+      def query=(query)
+        set_params parse_query_params(query)
+        super
+      end
+
+      # Ruby 2.1 or less uses #set_query to assign the query
       def set_query(query)
         set_params parse_query_params(query)
         super


### PR DESCRIPTION
Fixes #54.

Previous versions of Ruby used a `set_query` method, while the new version uses a `query=` method.
This breaks our hook to assign the params. Thus we override `query=` to fix it.

Alternatively, we could also go this way:

```ruby
if RUBY_VERSION >= '2.2'
  def query=(query)
    set_params parse_query_params(query)
    super
  end
else
  def set_query(query)
    set_params parse_query_params(query)
    super
  end
end
```

Which do you prefer?