### PR TITLE
Fix railtie_test generating unneeded log output on Railties 4.2.

### DIFF
--- a/test/cases/railtie_test.rb
+++ b/test/cases/railtie_test.rb
@@ -12,10 +12,9 @@ class RailtieTest < ActiveSupport::TestCase
 
   def setup
     Rails.env = 'development'
-    @app = BlogApp::Application.new do
-      config.eager_load = false
-      config.logger = Logger.new(nil)
-    end
+    @app = BlogApp::Application.new
+    @app.config.eager_load = false
+    @app.config.logger = Logger.new(nil)
   end
 
   test 'GlobalID.app for Blog::Application defaults to blog' do


### PR DESCRIPTION
Here's the output from running the tests:
```bash
# Running:

...................................................................................................config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true

config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true

..config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true

config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true

..config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true

.

Finished in 129662.543570s, 0.0008 runs/s, 0.0015 assertions/s.

104 runs, 200 assertions, 0 failures, 0 errors, 0 skips
```

There's also a log/development.log file generated.

It seems the setup block isn't run on 4.2. This is sort of a quick fix, which might not be the best way.
What do you think?