### PR TITLE
Remove caching in `to_signed_global_id`.

### DIFF
--- a/lib/global_id/identification.rb
+++ b/lib/global_id/identification.rb
@@ -10,7 +10,7 @@ class GlobalID
     alias to_gid to_global_id
 
     def to_signed_global_id(options = {})
-      @signed_global_id ||= SignedGlobalID.create(self, options)
+      SignedGlobalID.create(self, options)
     end
     alias to_sgid to_signed_global_id
   end


### PR DESCRIPTION
Fixes #58.

The options parameter prevents us from caching the return value of `create`.

Developing more advanced caching is not worth it, as `create` runs at
~10k per second - see benchmark pasted at #58.