### PR TITLE
create_from class method added into the GlobalId class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.ruby-version
 /Gemfile.lock
+globalid.db

--- a/globalid.gemspec
+++ b/globalid.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activesupport', '>= 4.1.0'
 
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'sqlite3-ruby'
+  s.add_development_dependency 'activerecord'
 end

--- a/lib/global_id/global_id.rb
+++ b/lib/global_id/global_id.rb
@@ -10,12 +10,11 @@ class GlobalID
     attr_reader :app
 
     def create(model, options = {})
-      if app = options.fetch(:app) { GlobalID.app }
-        new URI::GID.create(app, model), options
-      else
-        raise ArgumentError, 'An app is required to create a GlobalID. ' \
-          'Pass the :app option or set the default GlobalID.app.'
-      end
+      new URI::GID.create(get_app(options), model), options
+    end
+
+    def create_from(class_name, id, options = {})
+      new URI::GID.create_from(get_app(options), class_name, id), options
     end
 
     def find(gid, options = {})
@@ -41,6 +40,11 @@ class GlobalID
       def repad_gid(gid)
         padding_chars = gid.length.modulo(4).zero? ? 0 : (4 - gid.length.modulo(4))
         gid + ('=' * padding_chars)
+      end
+
+    protected
+      def get_app(options)
+        options.fetch(:app) { GlobalID.app } || raise(ArgumentError, 'An app is required to create a GlobalID. Pass the :app option or set the default GlobalID.app.')
       end
   end
 

--- a/lib/global_id/identification.rb
+++ b/lib/global_id/identification.rb
@@ -21,5 +21,31 @@ class GlobalID
     def to_sgid_param(options = {})
       to_signed_global_id(options).to_param
     end
+
+    ActiveRecord::Associations::Builder::BelongsTo.instance_eval do
+      def define_accessors(model, reflection)
+        class_name = reflection.options.fetch(:class_name, reflection.name.capitalize.to_s)
+        foreign_key = reflection.options.fetch(:foreign_key, "#{reflection.name}_id")
+
+        if reflection.options[:polymorphic]
+          class_name = "#{reflection.name}_type"
+        end
+
+        ["#{reflection.name}_gid", "#{reflection.name}_global_id"].each do |method|
+          model.send(:define_method, method) do
+            GlobalID.create_from(reflection.options[:polymorphic] ? send(class_name) : class_name, send(foreign_key))
+          end
+        end
+
+        ["#{reflection.name}_sgid", "#{reflection.name}_signed_global_id"].each do |method|
+          model.send(:define_method, method) do
+            SignedGlobalID.create_from(reflection.options[:polymorphic] ? send(class_name) : class_name, send(foreign_key))
+          end
+        end
+
+        super
+      end
+    end
+
   end
 end

--- a/lib/global_id/uri/gid.rb
+++ b/lib/global_id/uri/gid.rb
@@ -65,6 +65,10 @@ module URI
         build app: app, model_name: model.class.name, model_id: model.id, params: params
       end
 
+      def create_from(app, klass, id, params = nil)
+        build app: app, model_name: klass, model_id: id, params: params
+      end
+
       # Create a new URI::GID from components with argument check.
       #
       # The allowed components are app, model_name, model_id and params, which can be

--- a/test/cases/global_id_test.rb
+++ b/test/cases/global_id_test.rb
@@ -186,6 +186,11 @@ class GlobalIDCreationTest < ActiveSupport::TestCase
       person_gid = GlobalID.create(Person.new(5), app: nil)
     end
   end
+
+  test 'create_from class method' do
+    person_gid = GlobalID.create(Person.new(5))
+    assert_equal GlobalID.create_from("Person", 5), person_gid
+  end
 end
 
 class GlobalIDCustomParamsTest < ActiveSupport::TestCase

--- a/test/cases/global_identification_test.rb
+++ b/test/cases/global_identification_test.rb
@@ -3,6 +3,8 @@ require 'helper'
 class GlobalIdentificationTest < ActiveSupport::TestCase
   setup do
     @model = PersonModel.new id: 1
+    @user = User.create(name: "Abidik Gubidik")
+    @post = Post.create(name: "Sample Post", user: @user)
   end
 
   test 'creates a Global ID from self' do
@@ -18,5 +20,15 @@ class GlobalIdentificationTest < ActiveSupport::TestCase
   test 'creates a signed Global ID with purpose ' do
     assert_equal SignedGlobalID.create(@model, for: 'login'), @model.to_signed_global_id(for: 'login')
     assert_equal SignedGlobalID.create(@model, for: 'login'), @model.to_sgid(for: 'login')
+  end
+
+  test 'object.relation_gid & object.relation_global_id methods' do
+    assert_equal @post.user_gid, @user.to_gid
+    assert_equal @post.user_global_id, @user.to_gid
+  end
+
+  test 'object.relation_sgid & object.relation_signed_global_id methods' do
+    assert_equal @post.user_sgid, @user.to_sgid
+    assert_equal @post.user_signed_global_id, @user.to_sgid
   end
 end

--- a/test/cases/uri_gid_test.rb
+++ b/test/cases/uri_gid_test.rb
@@ -21,6 +21,10 @@ class URI::GIDTest <  ActiveSupport::TestCase
     assert_equal @gid_string, URI::GID.create('bcx', model).to_s
   end
 
+  test 'create_from' do
+    assert_equal @gid_string, URI::GID.create_from('bcx', "Person", 5).to_s
+  end
+
   test 'build' do
     array = URI::GID.build(['bcx', 'Person', '5', nil])
     assert array

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,8 +3,9 @@ require 'active_support'
 require 'active_support/testing/autorun'
 
 require 'global_id'
-require 'models/person'
-require 'models/person_model'
+require 'active_record'
+require 'support/db'
+Dir["#{File.dirname(__FILE__)}/models/*.rb"].each{|f| require f }
 
 require 'json'
 

--- a/test/models/post.rb
+++ b/test/models/post.rb
@@ -1,0 +1,6 @@
+class Post < ActiveRecord::Base
+  include GlobalID::Identification
+
+  belongs_to :user
+
+end

--- a/test/models/user.rb
+++ b/test/models/user.rb
@@ -1,0 +1,6 @@
+class User < ActiveRecord::Base
+  include GlobalID::Identification
+
+  has_many :posts
+
+end

--- a/test/support/db.rb
+++ b/test/support/db.rb
@@ -1,0 +1,12 @@
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "globalid.db")
+
+ActiveRecord::Schema.define(version: 0) do
+  create_table :users, force: true do |t|
+    t.string :name
+  end
+
+  create_table :posts, force: true do |t|
+    t.string :name
+    t.references :user
+  end
+end


### PR DESCRIPTION
create_from class method added into the GlobalId class for creating global id with model name and id capability
see the discussion on issue #59 