### PR TITLE
Move the `locate_many` AR specific code to the default locator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the model when it's time to perform the job. The job scheduler doesn't need to k
 the details of model naming and IDs, just that it has a global identifier that
 references a model.
 
-Another example is a drop-down list of options, consisting of both Users and Groups. 
+Another example is a drop-down list of options, consisting of both Users and Groups.
 Normally we'd need to come up with our own ad hoc scheme to reference them. With Global
 IDs, we have a universal identifier that works for objects of both classes.
 
@@ -55,7 +55,7 @@ For added security GlobalIDs can also be signed to ensure that the data hasn't b
 => #<Person:0x007fae94bf6298 @id="1">
 
 ```
-You can even bump the security up some more by explaining what purpose a Signed Global ID is for. 
+You can even bump the security up some more by explaining what purpose a Signed Global ID is for.
 In this way evildoers can't reuse a sign-up form's SGID on the login page. For example.
 
 ```ruby
@@ -66,7 +66,7 @@ In this way evildoers can't reuse a sign-up form's SGID on the login page. For e
 => #<Person:0x007fae94bf6298 @id="1">
 ```
 
-You can also have SGIDs that expire some time in the future. This is useful if there's a resource, 
+You can also have SGIDs that expire some time in the future. This is useful if there's a resource,
 people shouldn't have indefinite access to, like a share link.
 
 ```ruby
@@ -91,7 +91,7 @@ people shouldn't have indefinite access to, like a share link.
 
 ### Custom App Locator
 
-A custom locator can be set for an app by calling `GlobalID::Locator.use` and providing an app locator to use for that app. 
+A custom locator can be set for an app by calling `GlobalID::Locator.use` and providing an app locator to use for that app.
 A custom app locator is useful when different apps collaborate and reference each others' Global IDs.
 When finding a Global ID's model, the locator to use is based on the app name provided in the Global ID url.
 
@@ -116,7 +116,7 @@ class BarLocator
 end
 ```
 
-After defining locators as above, URIs like "gid://foo/Person/1" and "gid://bar/Person/1" will now use the foo block locator and `BarLocator` respectively. 
+After defining locators as above, URIs like "gid://foo/Person/1" and "gid://bar/Person/1" will now use the foo block locator and `BarLocator` respectively.
 Other apps will still keep using the default locator.
 
 ## License

--- a/test/cases/global_locator_test.rb
+++ b/test/cases/global_locator_test.rb
@@ -63,7 +63,7 @@ class GlobalLocatorTest < ActiveSupport::TestCase
   test 'by many GIDs of mixed classes' do
     assert_equal [ Person.new('1'), Person::Child.new('1'), Person.new('2') ],
       GlobalID::Locator.locate_many([ Person.new('1').to_gid, Person::Child.new('1').to_gid, Person.new('2').to_gid ])
-  end  
+  end
 
   test 'by many GIDs with only: restriction to match subclass' do
     assert_equal [ Person::Child.new('1') ],
@@ -127,7 +127,7 @@ class GlobalLocatorTest < ActiveSupport::TestCase
   test 'by many SGIDs of mixed classes' do
     assert_equal [ Person.new('1'), Person::Child.new('1'), Person.new('2') ],
       GlobalID::Locator.locate_many_signed([ Person.new('1').to_sgid, Person::Child.new('1').to_sgid, Person.new('2').to_sgid ])
-  end  
+  end
 
   test 'by many SGIDs with only: restriction to match subclass' do
     assert_equal [ Person::Child.new('1') ],
@@ -185,12 +185,14 @@ class GlobalLocatorTest < ActiveSupport::TestCase
   test 'use locator with class' do
     class BarLocator
       def locate(gid); :bar; end
+      def locate_many(gids, options = {}); gids.map(&:model_id); end
     end
 
     GlobalID::Locator.use :bar, BarLocator.new
 
     with_app 'bar' do
       assert_equal :bar, GlobalID::Locator.locate('gid://bar/Person/1')
+      assert_equal ['1', '2'], GlobalID::Locator.locate_many(['gid://bar/Person/1', 'gid://bar/Person/2'])
     end
   end
 


### PR DESCRIPTION
This is an extraction I've noticed that would make sense while reading through the source code. We have the locator abstraction to support non AR cases but `locate_many` is fixed on the AR API. One downside of this approach is that we can't locate multiple gids form different apps as the code uses the first gid to figure out which locator to use - but I don't think that is such a common use case for this.

If this makes sense, we should probably remove the AR specific notes in the `locate_many` documentation.