### PR TITLE
Raise a BlankIdError when converting an object without an id

### DIFF
--- a/lib/global_id/uri/gid.rb
+++ b/lib/global_id/uri/gid.rb
@@ -28,6 +28,9 @@ module URI
     alias :app :host
     attr_reader :model_name, :model_id, :params
 
+    # Raised when creating a Global ID for a model without an id
+    class MissingModelIdError < URI::InvalidComponentError; end
+
     class << self
       # Validates +app+'s as URI hostnames containing only alphanumeric characters
       # and hyphens. An ArgumentError is raised if +app+ is invalid.
@@ -141,7 +144,7 @@ module URI
       def set_model_components(path, validate = false)
         _, model_name, model_id = path.match(PATH_REGEXP).to_a
 
-        validate_component(model_name) && validate_component(model_id) if validate
+        validate_component(model_name) && validate_model_id(model_id, model_name) if validate
 
         @model_name = model_name
         @model_id = model_id
@@ -152,6 +155,13 @@ module URI
 
         raise URI::InvalidComponentError,
           "Expected a URI like gid://app/Person/1234: #{inspect}"
+      end
+
+      def validate_model_id(model_id, model_name)
+        return model_id unless model_id.blank?
+
+        raise MissingModelIdError, "Unable to create a Global ID for " \
+          "#{model_name} without a model id."
       end
 
       def parse_query_params(query)

--- a/test/cases/uri_gid_test.rb
+++ b/test/cases/uri_gid_test.rb
@@ -55,7 +55,8 @@ class URI::GIDValidationTest < ActiveSupport::TestCase
   end
 
   test 'missing model id' do
-    assert_invalid_component 'gid://bcx/Person'
+    err = assert_raise(URI::GID::MissingModelIdError) { URI::GID.parse('gid://bcx/Person') }
+    assert_match /Unable to create a Global ID for Person/, err.message
   end
 
   test 'too many model ids' do


### PR DESCRIPTION
Not sure if `UnidentifiedObject` is the best name? Perhaps `BlankId`?