### PR TITLE
Fix test helper check

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,8 +8,8 @@ require 'models/person_model'
 
 require 'json'
 
-if ActiveSupport::TestCase.respond_to?(:test_order)
-  # TODO: remove check once ActiveSupport depencency is at least 4.2
+if ActiveSupport::TestCase.respond_to?(:test_order=)
+  # TODO: remove check once ActiveSupport dependency is at least 4.2
   ActiveSupport::TestCase.test_order = :random
 end
 


### PR DESCRIPTION
Running on Rails 4.1.6 raises an error from tests, since we are cheking for `test_order` method(which exists) and instead

making use of `test_order=` method, which doesn't.

Fixed to verify, what we actually need to make sure exists.