### PR TITLE
Make the Active Record Locator use unscoped if it responds to it.

### DIFF
--- a/test/cases/global_locator_test.rb
+++ b/test/cases/global_locator_test.rb
@@ -248,3 +248,20 @@ class GlobalLocatorTest < ActiveSupport::TestCase
       GlobalID.app = old_app
     end
 end
+
+class ScopedRecordLocatingTest < ActiveSupport::TestCase
+  setup do
+    @gid = Person::Scoped.new('1').to_gid
+  end
+
+  test "by GID with scoped record" do
+    found = GlobalID::Locator.locate(@gid)
+    assert_kind_of @gid.model_class, found
+    assert_equal @gid.model_id, found.id
+  end
+
+  test "by many with scoped records" do
+    assert_equal [ Person::Scoped.new('1'), Person::Scoped.new('2') ],
+      GlobalID::Locator.locate_many([ Person::Scoped.new('1').to_gid, Person::Scoped.new('2').to_gid ])
+  end
+end

--- a/test/models/person.rb
+++ b/test/models/person.rb
@@ -33,4 +33,20 @@ class Person
   end
 end
 
+class Person::Scoped < Person
+  def initialize(*)
+    super
+    @find_allowed = false
+  end
+
+  def self.unscoped
+    @find_allowed = true
+    yield
+  end
+
+  def self.find(*)
+    super if @find_allowed
+  end
+end
+
 class Person::Child < Person; end


### PR DESCRIPTION
Fixes #66 

cc @matthewd @cristianbica