### PR TITLE
Use CGI.encode to handle model ids that are non-alphanumeric.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.ruby-version
+/.ruby-gemset
 /Gemfile.lock

--- a/lib/global_id/uri/gid.rb
+++ b/lib/global_id/uri/gid.rb
@@ -83,7 +83,7 @@ module URI
       def build(args)
         parts = Util.make_components_hash(self, args)
         parts[:host] = parts[:app]
-        parts[:path] = "/#{parts[:model_name]}/#{parts[:model_id]}"
+        parts[:path] = "/#{parts[:model_name]}/#{CGI.escape(parts[:model_id].to_s)}"
         parts[:query] = URI.encode_www_form(parts[:params]) if parts[:params]
 
         super parts
@@ -143,6 +143,7 @@ module URI
 
       def set_model_components(path, validate = false)
         _, model_name, model_id = path.match(PATH_REGEXP).to_a
+        model_id = CGI.unescape(model_id) if model_id
 
         validate_component(model_name) && validate_model_id(model_id, model_name) if validate
 

--- a/test/cases/uri_gid_test.rb
+++ b/test/cases/uri_gid_test.rb
@@ -45,6 +45,28 @@ class URI::GIDTest <  ActiveSupport::TestCase
   end
 end
 
+class URI::GIDModelIDEncodingTest < ActiveSupport::TestCase
+  test 'alphanumeric' do
+    model = Person.new('John123')
+    assert_equal 'gid://app/Person/John123', URI::GID.create('app', model).to_s
+  end
+
+  test 'non-alphanumeric' do
+    model = Person.new('John Doe-Smith/Jones')
+    assert_equal 'gid://app/Person/John+Doe-Smith%2FJones', URI::GID.create('app', model).to_s
+  end
+end
+
+class URI::GIDModelIDDecodingTest < ActiveSupport::TestCase
+  test 'alphanumeric' do
+    assert_equal 'John123', URI::GID.parse('gid://app/Person/John123').model_id
+  end
+
+  test 'non-alphanumeric' do
+    assert_equal 'John Doe-Smith/Jones', URI::GID.parse('gid://app/Person/John+Doe-Smith%2FJones').model_id
+  end
+end
+
 class URI::GIDValidationTest < ActiveSupport::TestCase
   test 'missing app' do
     assert_invalid_component 'gid:///Person/1'


### PR DESCRIPTION
Fix for #69.

Now `URI::GID` will escape the model_id.

```ruby
2.2.0 :004 > URI::GID.build(["app", "Post", 1, nil]).to_s
 => "gid://app/Post/1" 
2.2.0 :005 > URI::GID.build(["app", "Post", "Foo Baz & Bar", nil]).to_s
 => "gid://app/Post/Foo+Baz+%26+Bar" 
```
This should also be backwards compatbile with most existing usages.