### PR TITLE
#to_global_id should accept params

### DIFF
--- a/lib/global_id/global_id.rb
+++ b/lib/global_id/global_id.rb
@@ -11,7 +11,8 @@ class GlobalID
 
     def create(model, options = {})
       if app = options.fetch(:app) { GlobalID.app }
-        new URI::GID.create(app, model), options
+        params = options.except(:app, :verifier, :for)
+        new URI::GID.create(app, model, params), options
       else
         raise ArgumentError, 'An app is required to create a GlobalID. ' \
           'Pass the :app option or set the default GlobalID.app.'

--- a/lib/global_id/identification.rb
+++ b/lib/global_id/identification.rb
@@ -4,13 +4,13 @@ class GlobalID
   module Identification
     extend ActiveSupport::Concern
 
-    def to_global_id
-      @global_id ||= GlobalID.create(self)
+    def to_global_id(options = {})
+      @global_id ||= GlobalID.create(self, options)
     end
     alias to_gid to_global_id
 
-    def to_gid_param
-      to_global_id.to_param
+    def to_gid_param(options = {})
+      to_global_id(options).to_param
     end
 
     def to_signed_global_id(options = {})

--- a/lib/global_id/uri/gid.rb
+++ b/lib/global_id/uri/gid.rb
@@ -84,7 +84,10 @@ module URI
         parts = Util.make_components_hash(self, args)
         parts[:host] = parts[:app]
         parts[:path] = "/#{parts[:model_name]}/#{CGI.escape(parts[:model_id].to_s)}"
-        parts[:query] = URI.encode_www_form(parts[:params]) if parts[:params]
+
+        if parts[:params] && !parts[:params].empty?
+          parts[:query] = URI.encode_www_form(parts[:params])
+        end
 
         super parts
       end

--- a/test/cases/global_id_test.rb
+++ b/test/cases/global_id_test.rb
@@ -189,7 +189,12 @@ class GlobalIDCreationTest < ActiveSupport::TestCase
 end
 
 class GlobalIDCustomParamsTest < ActiveSupport::TestCase
-  test 'custom params' do
+  test 'create custom params' do
+    gid = GlobalID.create(Person.new(5), hello: 'world')
+    assert_equal 'world', gid.params[:hello]
+  end
+
+  test 'parse custom params' do
     gid = GlobalID.parse 'gid://bcx/Person/5?hello=world'
     assert_equal 'world', gid.params[:hello]
   end

--- a/test/cases/global_identification_test.rb
+++ b/test/cases/global_identification_test.rb
@@ -10,6 +10,11 @@ class GlobalIdentificationTest < ActiveSupport::TestCase
     assert_equal GlobalID.create(@model), @model.to_gid
   end
 
+  test 'creates a Global ID with custom params' do
+    assert_equal GlobalID.create(@model, some: 'param'), @model.to_global_id(some: 'param')
+    assert_equal GlobalID.create(@model, some: 'param'), @model.to_gid(some: 'param')
+  end
+
   test 'creates a signed Global ID from self' do
     assert_equal SignedGlobalID.create(@model), @model.to_signed_global_id
     assert_equal SignedGlobalID.create(@model), @model.to_sgid
@@ -18,5 +23,10 @@ class GlobalIdentificationTest < ActiveSupport::TestCase
   test 'creates a signed Global ID with purpose ' do
     assert_equal SignedGlobalID.create(@model, for: 'login'), @model.to_signed_global_id(for: 'login')
     assert_equal SignedGlobalID.create(@model, for: 'login'), @model.to_sgid(for: 'login')
+  end
+
+  test 'creates a signed Global ID with custom params' do
+    assert_equal SignedGlobalID.create(@model, some: 'param'), @model.to_signed_global_id(some: 'param')
+    assert_equal SignedGlobalID.create(@model, some: 'param'), @model.to_sgid(some: 'param')
   end
 end

--- a/test/cases/signed_global_id_test.rb
+++ b/test/cases/signed_global_id_test.rb
@@ -219,3 +219,15 @@ class SignedGlobalIDExpirationTest < ActiveSupport::TestCase
       SignedGlobalID.expires_in = old_expires
     end
 end
+
+class SignedGlobalIDCustomParamsTest < ActiveSupport::TestCase
+  test 'create custom params' do
+    sgid = SignedGlobalID.create(Person.new(5), hello: 'world')
+    assert_equal 'world', sgid.params[:hello]
+  end
+
+  test 'parse custom params' do
+    sgid = SignedGlobalID.parse('eyJnaWQiOiJnaWQ6Ly9iY3gvUGVyc29uLzU/aGVsbG89d29ybGQiLCJwdXJwb3NlIjoiZGVmYXVsdCIsImV4cGlyZXNfYXQiOm51bGx9--7c042f09483dec470fa1088b76d9fd946eb30ffa')
+    assert_equal 'world', sgid.params[:hello]
+  end
+end


### PR DESCRIPTION
Since `URI::GID.create` allows params, it seems like `#to_global_id` would accept a params hash. This would be convenient for non-standard cases like multiple databases.