### PR TITLE
to_global_id no longer caches its first call

### DIFF
--- a/lib/global_id/identification.rb
+++ b/lib/global_id/identification.rb
@@ -5,7 +5,7 @@ class GlobalID
     extend ActiveSupport::Concern
 
     def to_global_id(options = {})
-      @global_id ||= GlobalID.create(self, options)
+      GlobalID.create(self, options)
     end
     alias to_gid to_global_id
 


### PR DESCRIPTION
Since to_global_id takes an options value, caching the result causes any subsequent calls with different options to be incorrect. Also to_signed_global_id doesn't cache it's value, so the two methods are not consistent with each other.
