### PR TITLE
fix example of `locate_signed` [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ In this way evildoers can't reuse a sign-up form's SGID on the login page. For e
 >> signup_person_sgid = Person.find(1).to_sgid(for: 'signup_form')
 => #<SignedGlobalID:0x007fea1984b520
 
->> GlobalID::Locator.locate_signed(signup_person_sgid, for: 'signup_form')
+>> GlobalID::Locator.locate_signed(signup_person_sgid.to_s, for: 'signup_form')
 => #<Person:0x007fae94bf6298 @id="1">
 ```
 
@@ -74,18 +74,18 @@ people shouldn't have indefinite access to, like a share link.
 => #<SignedGlobalID:0x008fde45df8937
 
 # Within 2 hours...
->> GlobalID::Locator.locate_signed(expiring_sgid, for: 'sharing')
+>> GlobalID::Locator.locate_signed(expiring_sgid.to_s, for: 'sharing')
 => #<Document:0x007fae94bf6298 @id="5">
 
 # More than 2 hours later...
->> GlobalID::Locator.locate_signed(expiring_sgid, for: 'sharing')
+>> GlobalID::Locator.locate_signed(expiring_sgid.to_s, for: 'sharing')
 => nil
 
 >> explicit_expiring_sgid = SecretAgentMessage.find(5).to_sgid(expires_at: Time.now.advance(hours: 1))
 => #<SignedGlobalID:0x008fde45df8937
 
 # 1 hour later...
->> GlobalID::Locator.locate_signed explicit_expiring_sgid
+>> GlobalID::Locator.locate_signed explicit_expiring_sgid.to_s
 => nil
 ```
 


### PR DESCRIPTION
Currently, if pass an instance of `SignedGlobalID` to `locate_signed`,
it does not perform verify the options.
https://github.com/rails/globalid/blob/master/lib/global_id/signed_global_id.rb#L12..L16

Therefore, in order to perform the verify options correctly, need to pass string.