### PR TITLE
Fix master build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ cache: bundler
 rvm:
 - 1.9.3
 - 2.0.0
-- 2.1
-- 2.2
-- 2.3.0
+- 2.1.10
+- 2.2.5
+- 2.3.1
 - ruby-head
 - rbx-2
 - jruby
@@ -26,7 +26,7 @@ matrix:
     gemfile: gemfiles/rails_5.0.gemfile
   - rvm: 2.0.0
     gemfile: gemfiles/rails_5.0.gemfile
-  - rvm: 2.1
+  - rvm: 2.1.10
     gemfile: gemfiles/rails_5.0.gemfile
   allow_failures:
   - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 sudo: false
 before_install:
   - gem install bundler
-  - "rm ${BUNDLE_GEMFILE}.lock"
+  - "rm -f ${BUNDLE_GEMFILE}.lock"
 before_script:
   - bundle update
 cache: bundler
@@ -16,7 +16,18 @@ rvm:
 - ruby-head
 - rbx-2
 - jruby
+gemfile:
+- gemfiles/rails_4.1.gemfile
+- gemfiles/rails_4.2.gemfile
+- gemfiles/rails_5.0.gemfile
 matrix:
+  exclude:
+  - rvm: 1.9.3
+    gemfile: gemfiles/rails_5.0.gemfile
+  - rvm: 2.0.0
+    gemfile: gemfiles/rails_5.0.gemfile
+  - rvm: 2.1
+    gemfile: gemfiles/rails_5.0.gemfile
   allow_failures:
   - rvm: rbx-2
   - rvm: jruby

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "activemodel", "~> 4.1.0"
+gem "railties", "~> 4.1.0"
+
+gemspec path: "../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "activemodel", "~> 4.2.0"
+gem "railties", "~> 4.2.0"
+
+gemspec path: "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "activemodel", "~> 5.0.0"
+gem "railties", "~> 5.0.0"
+
+gemspec path: "../"


### PR DESCRIPTION
Rails 5.0.0 only supports Ruby 2.2 or more.
Fix to perform a test of Rails 5.0.0 only in Ruby 2.2 or more.