### PR TITLE
verify purpose when pass `SignedGlobalID` to `locate_signed`

### DIFF
--- a/lib/global_id/signed_global_id.rb
+++ b/lib/global_id/signed_global_id.rb
@@ -9,11 +9,8 @@ class SignedGlobalID < GlobalID
     attr_accessor :verifier
 
     def parse(sgid, options = {})
-      if sgid.is_a? self
-        sgid
-      else
-        super verify(sgid, options), options
-      end
+      signed_message = sgid.is_a?(self) ? sgid.to_s : sgid
+      super verify(signed_message, options), options
     end
 
     # Grab the verifier from options and fall back to SignedGlobalID.verifier.

--- a/test/cases/global_locator_test.rb
+++ b/test/cases/global_locator_test.rb
@@ -221,11 +221,27 @@ class GlobalLocatorTest < ActiveSupport::TestCase
     assert_equal login_sgid.model_id, found.id
   end
 
+  test "by valid purpose with SGID returns right model" do
+    instance = Person.new
+    login_sgid = instance.to_signed_global_id(for: 'login')
+
+    found = GlobalID::Locator.locate_signed(login_sgid, for: 'login')
+    assert_kind_of login_sgid.model_class, found
+    assert_equal login_sgid.model_id, found.id
+  end
+
   test "by invalid purpose returns nil" do
     instance = Person.new
     login_sgid = instance.to_signed_global_id(for: 'login')
 
     assert_nil GlobalID::Locator.locate_signed(login_sgid.to_s, for: 'like_button')
+  end
+
+  test "by invalid purpose with SGID returns nil" do
+    instance = Person.new
+    login_sgid = instance.to_signed_global_id(for: 'login')
+
+    assert_nil GlobalID::Locator.locate_signed(login_sgid, for: 'like_button')
   end
 
   test "by many with one record missing leading to a raise" do


### PR DESCRIPTION
Currently, if pass an instance of `SignedGlobalID` to `locate_signed`,
does not verify purpose. But it seems a bit strange.
I think that should verify even if pass an instance of SignedGlobalID.