### PR TITLE
Use json-1.8.6 for Ruby 2.4.0 compatibility.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    globalid (0.3.6)
+    globalid (0.3.7)
       activesupport (>= 4.1.0)
 
 GEM
@@ -32,7 +32,7 @@ GEM
     builder (3.2.2)
     erubis (2.7.0)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mini_portile2 (2.0.0)
@@ -71,4 +71,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.10.6
+   1.14.3


### PR DESCRIPTION
I want to use Ruby 2.4.0 for `globalid` development.
I want to use `json-1.8.6` instead of `json-1.8.3` for Ruby 2.4.0 compatibility.

Ideally I think it might be better not to manage `Gemfile.lock` in git (`git rm Gemfile.lock`). If we want to specify dependency gem version, we can use `globalid.gemspec` and `Gemfile`. We can test `globalid` with intended dependency new version gem packages.

```
$ git clone git@github.com:rails/globalid.git

$ cd globalid

$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]

$ bundle -v
Bundler version 1.14.3

$ bundle install --path vendor/bundle
...
Using bundler 1.14.3
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/home/jaruga/git/globalid/vendor/bundle/ruby/2.4.0/gems/json-1.8.3/ext/json/ext/generator
/usr/local/ruby-2.4.0/bin/ruby -r ./siteconf20170213-6623-1wcvrjy.rb extconf.rb 
creating Makefile

current directory:
/home/jaruga/git/globalid/vendor/bundle/ruby/2.4.0/gems/json-1.8.3/ext/json/ext/generator
make "DESTDIR=" clean

current directory:
/home/jaruga/git/globalid/vendor/bundle/ruby/2.4.0/gems/json-1.8.3/ext/json/ext/generator
make "DESTDIR="
compiling generator.c
generator.c: In function ‘generate_json’:
generator.c:861:25: error: ‘rb_cFixnum’ undeclared (first use in this function)
     } else if (klass == rb_cFixnum) {
                         ^~~~~~~~~~
generator.c:861:25: note: each undeclared identifier is reported only once for each
function it appears in
generator.c:863:25: error: ‘rb_cBignum’ undeclared (first use in this function)
     } else if (klass == rb_cBignum) {
                         ^~~~~~~~~~
generator.c: At top level:
cc1: warning: unrecognized command line option ‘-Wno-self-assign’
cc1: warning: unrecognized command line option ‘-Wno-constant-logical-operand’
cc1: warning: unrecognized command line option ‘-Wno-parentheses-equality’
Makefile:241: recipe for target 'generator.o' failed
make: *** [generator.o] Error 1

make failed, exit code 2
...
```
