### PR TITLE
Add Ruby 2.4.0 to Traivs CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ rvm:
 - 2.1.10
 - 2.2.5
 - 2.3.1
+- 2.4.0
 - ruby-head
 - rbx-2
 - jruby
@@ -28,6 +29,8 @@ matrix:
     gemfile: gemfiles/rails_5.0.gemfile
   - rvm: 2.1.10
     gemfile: gemfiles/rails_5.0.gemfile
+  - rvm: 2.4.0
+    gemfile: gemfiles/rails_4.1.gemfile
   allow_failures:
   - rvm: rbx-2
   - rvm: jruby

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "activemodel", "~> 4.2.0"
-gem "railties", "~> 4.2.0"
+gem "activemodel", :github => "rails/rails", :branch => "4-2-stable"
+gem "railties", :github => "rails/rails", :branch => "4-2-stable"
 
 gemspec path: "../"


### PR DESCRIPTION
Maybe it's time to add Ruby 2.4.0 to Traivs.
