### PR TITLE
Generate URL-safe SGIDs

### DIFF
--- a/lib/global_id.rb
+++ b/lib/global_id.rb
@@ -5,4 +5,5 @@ autoload :SignedGlobalID, 'global_id/signed_global_id'
 class GlobalID
   autoload :Locator, 'global_id/locator'
   autoload :Identification, 'global_id/identification'
+  autoload :Verifier, 'global_id/verifier'
 end

--- a/lib/global_id/railtie.rb
+++ b/lib/global_id/railtie.rb
@@ -22,7 +22,7 @@ class GlobalID
 
       config.after_initialize do
         app.config.global_id.verifier ||= begin
-          app.message_verifier(:signed_global_ids)
+          GlobalID::Verifier.new(app.key_generator.generate_key('signed_global_ids'))
         rescue ArgumentError
           nil
         end

--- a/lib/global_id/verifier.rb
+++ b/lib/global_id/verifier.rb
@@ -1,0 +1,15 @@
+require 'active_support'
+require 'active_support/message_verifier'
+
+class GlobalID
+  class Verifier < ActiveSupport::MessageVerifier
+    private
+      def encode(data)
+        ::Base64.urlsafe_encode64(data)
+      end
+
+      def decode(data)
+        ::Base64.urlsafe_decode64(data)
+      end
+  end
+end

--- a/test/cases/verifier_test.rb
+++ b/test/cases/verifier_test.rb
@@ -1,0 +1,30 @@
+require 'helper'
+
+class VerifierTest < ActiveSupport::TestCase
+  setup do
+    @verifier = GlobalID::Verifier.new('muchSECRETsoHIDDEN')
+  end
+
+  # Marshal.dump serializes the hash used in this test to a different string in older versions of Ruby.
+  if RUBY_VERSION > "1.9.3"
+    test "generates URL-safe messages" do
+      assert_equal "BAh7B0kiCGdpZAY6BkVUSSInZ2lkOi8vYmN4L1BlcnNvbi8xMTUxODY_ZXhwaXJlc19pbgY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--fa4b8c7a28d213288fdd9b6764a5dd119a18a6fe",
+        @verifier.generate({ "gid" => "gid://bcx/Person/115186?expires_in", "expires_at" => nil })
+    end
+  else
+    test "generates URL-safe messages" do
+      assert_equal "BAh7B0kiCGdpZAY6BkVGSSInZ2lkOi8vYmN4L1BlcnNvbi8xMTUxODY_ZXhwaXJlc19pbgY7AEZJIg9leHBpcmVzX2F0BjsARjA=--b52bf45c68710c5c80e04e44fb122be11f9f2c49",
+        @verifier.generate({ "gid" => "gid://bcx/Person/115186?expires_in", "expires_at" => nil })
+    end
+  end
+
+  test "verifies URL-safe messages" do
+    assert_equal({ "gid" => "gid://bcx/Person/115186?expires_in", "expires_at" => nil },
+      @verifier.verify("BAh7B0kiCGdpZAY6BkVUSSInZ2lkOi8vYmN4L1BlcnNvbi8xMTUxODY_ZXhwaXJlc19pbgY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--fa4b8c7a28d213288fdd9b6764a5dd119a18a6fe"))
+  end
+
+  test "verifies non-URL-safe messages" do
+    assert_equal({ "gid" => "gid://bcx/Person/115186?expires_in", "expires_at" => nil },
+      @verifier.verify("BAh7B0kiCGdpZAY6BkVUSSInZ2lkOi8vYmN4L1BlcnNvbi8xMTUxODY/ZXhwaXJlc19pbgY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--ae5e44055262447fdbf5d5d39d5120cfa7d5fbe6"))
+  end
+end


### PR DESCRIPTION
We use SGIDs in some URLs sent via email from Basecamp. Since Basecamp 3’s launch, we’ve heard reports of broken links in emails from customers whose mail clients decode slashes in URL-encoded SGIDs.

For example, errant mail clients turn an SGID such as (a) below, which Rails parses as one path segment, into (b), which Rails parses as two path segments.

<pre><code>(a) BAh7B0kiCGdpZAY6BkVUSSInZ2lkOi8vYmN4L1BlcnNvbi8xMTUxOD<strong>Y%2FZ</strong>XhwaXJlc19pbgY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--ae5e44055262447fdbf5d5d39d5120cfa7d5fbe6
(b) BAh7B0kiCGdpZAY6BkVUSSInZ2lkOi8vYmN4L1BlcnNvbi8xMTUxOD<strong>Y/Z</strong>XhwaXJlc19pbgY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--ae5e44055262447fdbf5d5d39d5120cfa7d5fbe6
</code></pre>

Unfortunately, we’ve been unable to identify exactly which mail clients mangle SGIDs in this way.

Global ID already <a href="https://github.com/rails/globalid/blob/master/lib/global_id/global_id.rb#L69">ensures unsigned GIDs are safe for use in URLs</a>. To circumvent problematic mail clients, it can do the same for signed GIDs. This PR implements a custom message verifier that prefers URL-safe base64 encoding, `GlobalID::Verifier`,  and makes it the default for SGID generation. `GlobalID::Verifier` accepts SGIDs generated with `ActiveSupport::MessageVerifier` for backwards compatibility.

/cc @jeremy 