### PR TITLE
Memoize global id conversion according to options

### DIFF
--- a/lib/global_id/identification.rb
+++ b/lib/global_id/identification.rb
@@ -5,7 +5,8 @@ class GlobalID
     extend ActiveSupport::Concern
 
     def to_global_id(options = {})
-      @global_id ||= GlobalID.create(self, options)
+      @global_id_cache ||= {}
+      @global_id_cache[options] ||= GlobalID.create(self, options)
     end
     alias to_gid to_global_id
 

--- a/test/cases/global_identification_test.rb
+++ b/test/cases/global_identification_test.rb
@@ -15,6 +15,11 @@ class GlobalIdentificationTest < ActiveSupport::TestCase
     assert_equal GlobalID.create(@model, some: 'param'), @model.to_gid(some: 'param')
   end
 
+  test 'creates a Global ID with different sets of custom params' do
+    assert_equal GlobalID.create(@model, some: 'param'), @model.to_global_id(some: 'param')
+    assert_equal GlobalID.create(@model, other: 'param'), @model.to_global_id(other: 'param')
+  end
+
   test 'creates a signed Global ID from self' do
     assert_equal SignedGlobalID.create(@model), @model.to_signed_global_id
     assert_equal SignedGlobalID.create(@model), @model.to_sgid


### PR DESCRIPTION
I noticed when reading the `GlobalID::Identification#to_global_id`
code that ivar memoization is performed without consideration of
the options passed.

Before this change:

```irb
>> user.to_global_id(foo: :bar)
=> #<GlobalID:0x007fcb41aa0d70 @uri=#<URI::GID gid://app/User/1?foo=bar>>
>> user.to_global_id(fizz: :buzz)
=> #<GlobalID:0x007fcb41aa0d70 @uri=#<URI::GID gid://app/User/1?foo=bar>>
```

After this change:

```irb
>> user.to_global_id(foo: :bar)
=> #<GlobalID:0x007fcb42411f58 @uri=#<URI::GID gid://app/User/1?foo=bar>>
>> user.to_global_id(fizz: :buzz)
=> #<GlobalID:0x007fcb423d7740 @uri=#<URI::GID gid://app/User/1?fizz=buzz>>
```

Some potential concerns:

- Perhaps folks out there have used `@global_id`
- `self` is still not considered in memoization, though this is less
  likely a problem as `#id` matters and typically doesn't change
- Weird dormant memoization bugs spring to life in existing code (time
  or random params). This is pretty out there.