### PR TITLE
Eager load the constants

### DIFF
--- a/lib/global_id.rb
+++ b/lib/global_id.rb
@@ -1,9 +1,19 @@
 require 'global_id/global_id'
+require 'active_support'
 
 autoload :SignedGlobalID, 'global_id/signed_global_id'
 
 class GlobalID
-  autoload :Locator, 'global_id/locator'
-  autoload :Identification, 'global_id/identification'
-  autoload :Verifier, 'global_id/verifier'
+  extend ActiveSupport::Autoload
+
+  eager_autoload do
+    autoload :Locator
+    autoload :Identification
+    autoload :Verifier
+  end
+
+  def self.eager_load!
+    super
+    require 'global_id/signed_global_id'
+  end
 end

--- a/lib/global_id/railtie.rb
+++ b/lib/global_id/railtie.rb
@@ -11,6 +11,7 @@ class GlobalID
   # Set up the signed GlobalID verifier and include Active Record support.
   class Railtie < Rails::Railtie # :nodoc:
     config.global_id = ActiveSupport::OrderedOptions.new
+    config.eager_load_namespaces << GlobalID
 
     initializer 'global_id' do |app|
 


### PR DESCRIPTION
In a thread-based backend like Sidekiq, there is a possibility that autoload may occur simultaneously in multiple threads, and as a result, it is presumed that an error may be caused by contention of autoload.

In order to avoid the above issue, eager load the constants on boot.
Maybe fixes #101

Context: https://github.com/rails/rails/pull/30217#issuecomment-322012021