### PR TITLE
test reproducing undesired character "=" appearing in to_param result

### DIFF
--- a/test/cases/signed_global_id_test.rb
+++ b/test/cases/signed_global_id_test.rb
@@ -29,6 +29,11 @@ class SignedGlobalIDTest < ActiveSupport::TestCase
   test 'to param' do
     assert_equal @person_sgid.to_s, @person_sgid.to_param
   end
+
+  test 'to param produces param friendly value' do
+    sgid = SignedGlobalID.create(Person.new(25))
+    assert_not_includes sgid.to_param, "="
+  end
 end
 
 class SignedGlobalIDVerifierTest < ActiveSupport::TestCase

--- a/test/cases/signed_global_id_test.rb
+++ b/test/cases/signed_global_id_test.rb
@@ -27,7 +27,7 @@ class SignedGlobalIDTest < ActiveSupport::TestCase
   end
 
   test 'to param' do
-    assert_equal @person_sgid.to_s, @person_sgid.to_param
+    assert_equal "ZXlKbmFXUWlPaUpuYVdRNkx5OWlZM2d2VUdWeWMyOXVMelVpTENKd2RYSndiM05sSWpvaVpHVm1ZWFZzZENJc0ltVjRjR2x5WlhOZllYUWlPbTUxYkd4OS0tMDRhNmY1OTE0MDI1OTc1NmIyMjAwOGM4YzBmNzZlYTVlZDQ4NTU3OQ", @person_sgid.to_param
   end
 
   test 'to param produces param friendly value' do


### PR DESCRIPTION
SignedGlobalID#to_param currently may produce strings containing the character "=".
In the unsigned version to_param and parse removes and deals with their absence respectively making their us in url_params a straightforward experience.
The same does not happen with their signed counterpart which its use is encouraged for such cases.

Todo:
- [x] fix ;)