### PR TITLE
Array#uniq to correctly identify == GlobalIDs

### DIFF
--- a/lib/global_id/global_id.rb
+++ b/lib/global_id/global_id.rb
@@ -63,6 +63,11 @@ class GlobalID
   def ==(other)
     other.is_a?(GlobalID) && @uri == other.uri
   end
+  alias_method :eql?, :==
+
+  def hash
+    self.class.hash | @uri.hash
+  end
 
   def to_param
     # remove the = padding character for a prettier param -- it'll be added back in parse_encoded_gid

--- a/test/cases/global_id_test.rb
+++ b/test/cases/global_id_test.rb
@@ -190,6 +190,30 @@ class GlobalIDCreationTest < ActiveSupport::TestCase
       person_gid = GlobalID.create(Person.new(5), app: nil)
     end
   end
+
+  test 'equality' do
+    p1 = Person.new(5)
+    p2 = Person.new(5)
+    p3 = Person.new(10)
+    assert_equal p1, p2
+    assert_not_equal p2, p3
+
+    gid1 = GlobalID.create(p1)
+    gid2 = GlobalID.create(p2)
+    gid3 = GlobalID.create(p3)
+    assert_equal gid1, gid2
+    assert_not_equal gid2, gid3
+
+    # hash and eql? to match for two GlobalID's pointing to the same object
+    assert_equal [gid1], [gid1, gid2].uniq
+    assert_equal [gid1, gid3], [gid1, gid2, gid3].uniq
+
+    # verify that the GlobalID's hash is different to the underlaying URI
+    assert_not_equal gid1.hash, gid1.uri.hash
+
+    # verify that URI and GlobalID do not pass the uniq test
+    assert_equal [gid1, gid1.uri], [gid1, gid1.uri].uniq
+  end
 end
 
 class GlobalIDCustomParamsTest < ActiveSupport::TestCase


### PR DESCRIPTION
When performing an Array#uniq with two GlobalID objects that are `==`, the result of the uniq still contains the "duplicate" entries.

This PR changes the `hash` method to consider the `hash` of the underlaying URI hash so that two GlobalID objects pointing to the same object are considered duplicates of each other.

Previously, with:
p1 = GlobalID.create(Person.new(1))
p2 = GlobalID.create(Person.new(1))

`p1 == p2 #=> true` but `[p1, p2].uniq #=> [p1, p2]`