### PR TITLE
GlobalID::Identification clears memoized to_global_id on dup

### DIFF
--- a/lib/global_id/identification.rb
+++ b/lib/global_id/identification.rb
@@ -5,7 +5,7 @@ class GlobalID
     extend ActiveSupport::Concern
 
     def to_global_id(options = {})
-      @global_id ||= GlobalID.create(self, options)
+      GlobalID.create(self, options)
     end
     alias to_gid to_global_id
 
@@ -20,11 +20,6 @@ class GlobalID
 
     def to_sgid_param(options = {})
       to_signed_global_id(options).to_param
-    end
-
-    def initialize_dup(other)
-      @global_id = nil
-      super
     end
   end
 end

--- a/lib/global_id/identification.rb
+++ b/lib/global_id/identification.rb
@@ -21,5 +21,10 @@ class GlobalID
     def to_sgid_param(options = {})
       to_signed_global_id(options).to_param
     end
+
+    def initialize_dup(other)
+      @global_id = nil
+      super
+    end
   end
 end

--- a/test/cases/global_identification_test.rb
+++ b/test/cases/global_identification_test.rb
@@ -29,4 +29,12 @@ class GlobalIdentificationTest < ActiveSupport::TestCase
     assert_equal SignedGlobalID.create(@model, some: 'param'), @model.to_signed_global_id(some: 'param')
     assert_equal SignedGlobalID.create(@model, some: 'param'), @model.to_sgid(some: 'param')
   end
+
+  test 'dup should clear memoized to_global_id' do
+    global_id = @model.to_global_id
+    dup_model = @model.dup
+    dup_model.id = @model.id + 1
+    dup_global_id = dup_model.to_global_id
+    assert_not_equal global_id, dup_global_id
+  end
 end


### PR DESCRIPTION
This module is used in ActiveRecord, which resets the model's primary key on
`dup`. If we don't clear it here, then a `dup`ed ActiveRecord instance can have
an invalid GlobalID.

See https://github.com/rails/rails/issues/33679