### PR TITLE
Allow configuration in initializers

### DIFF
--- a/lib/global_id/railtie.rb
+++ b/lib/global_id/railtie.rb
@@ -14,14 +14,16 @@ class GlobalID
     config.eager_load_namespaces << GlobalID
 
     initializer 'global_id' do |app|
+      default_expires_in = 1.month
+      default_app_name = app.railtie_name.remove('_application').dasherize
 
-      app.config.global_id.app ||= app.railtie_name.remove('_application').dasherize
-      GlobalID.app = app.config.global_id.app
-
-      app.config.global_id.expires_in ||= 1.month
-      SignedGlobalID.expires_in = app.config.global_id.expires_in
+      GlobalID.app = app.config.global_id.app ||= default_app_name
+      SignedGlobalID.expires_in = app.config.global_id.expires_in ||= default_expires_in
 
       config.after_initialize do
+        GlobalID.app = app.config.global_id.app ||= default_app_name
+        SignedGlobalID.expires_in = app.config.global_id.expires_in ||= default_expires_in
+
         app.config.global_id.verifier ||= begin
           GlobalID::Verifier.new(app.key_generator.generate_key('signed_global_ids'))
         rescue ArgumentError

--- a/test/cases/railtie_test.rb
+++ b/test/cases/railtie_test.rb
@@ -28,6 +28,18 @@ class RailtieTest < ActiveSupport::TestCase
     assert_equal 'foo', GlobalID.app
   end
 
+  test 'config.global_id can be used to set configurations after the railtie has been loaded' do
+    @app.config.eager_load = true
+    @app.config.before_eager_load do
+      @app.config.global_id.app = 'foobar'
+      @app.config.global_id.expires_in = 1.year
+    end
+
+    @app.initialize!
+    assert_equal 'foobar', GlobalID.app
+    assert_equal 1.year, SignedGlobalID.expires_in
+  end
+
   test 'SignedGlobalID.verifier defaults to Blog::Application.message_verifier(:signed_global_ids) when secret_token is present' do
     @app.config.secret_token = ('x' * 30)
     @app.initialize!


### PR DESCRIPTION
Closes https://github.com/rails/globalid/issues/105

This sets `GlobalID.app` and `SecureGlobalID.expires_in` to the default
values and then allows overwriting them via `config.global_id.app` and
`config.global_id.expires_in` in an `config/initializers/*.rb`
file.