### PR TITLE
Drop unused Travis sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 ---
 language: ruby
-sudo: false
 before_install:
   - "travis_retry gem install bundler || travis_retry gem install bundler -v 1.17.3"
   - "rm -f ${BUNDLE_GEMFILE}.lock"


### PR DESCRIPTION
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).