### PR TITLE
Require time core extension for 1.year

### DIFF
--- a/lib/global_id/railtie.rb
+++ b/lib/global_id/railtie.rb
@@ -5,6 +5,7 @@ else
 require 'global_id'
 require 'active_support'
 require 'active_support/core_ext/string/inflections'
+require 'active_support/core_ext/integer/time'
 
 class GlobalID
   # = GlobalID Railtie


### PR DESCRIPTION
Since 39ab83a43a64b339739c6e8c7ab24bb1325204ed this file uses `1.year` without requiring the core extension that defines it.