### PR TITLE
Use 5-2-stable branch to fix Ruby 2.2 CI

### DIFF
--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
 gem "activemodel", "~> 5.2.0"
-gem "railties", "~> 5.2.0"
+gem "railties", git: "https://github.com/rails/rails", branch: "5-2-stable"
 
 gemspec path: "../"


### PR DESCRIPTION
Rails 5.2.4.2 accidentally broke compatibility with Ruby 2.2 by using the safe navigation operator (https://github.com/rails/rails/issues/38972). It's been fixed on the 5-2-stable branch, but there may never be another 5.2 release, so to get CI passing we'll have to use the branch.