### PR TITLE
Allow expires_in to be configured to nil globally

### DIFF
--- a/lib/global_id/railtie.rb
+++ b/lib/global_id/railtie.rb
@@ -19,11 +19,11 @@ class GlobalID
       default_app_name = app.railtie_name.remove('_application').dasherize
 
       GlobalID.app = app.config.global_id.app ||= default_app_name
-      SignedGlobalID.expires_in = app.config.global_id.expires_in ||= default_expires_in
+      SignedGlobalID.expires_in = app.config.global_id.fetch(:expires_in, default_expires_in)
 
       config.after_initialize do
         GlobalID.app = app.config.global_id.app ||= default_app_name
-        SignedGlobalID.expires_in = app.config.global_id.expires_in ||= default_expires_in
+        SignedGlobalID.expires_in = app.config.global_id.fetch(:expires_in, default_expires_in)
 
         app.config.global_id.verifier ||= begin
           GlobalID::Verifier.new(app.key_generator.generate_key('signed_global_ids'))

--- a/test/cases/railtie_test.rb
+++ b/test/cases/railtie_test.rb
@@ -29,6 +29,12 @@ class RailtieTest < ActiveSupport::TestCase
     assert_equal 'foo', GlobalID.app
   end
 
+  test 'SignedGlobalID.expires_in can be explicitly set to nil with config.global_id.expires_in' do
+    @app.config.global_id.expires_in = nil
+    @app.initialize!
+    assert_nil SignedGlobalID.expires_in
+  end
+
   test 'config.global_id can be used to set configurations after the railtie has been loaded' do
     @app.config.eager_load = true
     @app.config.before_eager_load do
@@ -40,6 +46,17 @@ class RailtieTest < ActiveSupport::TestCase
     assert_equal 'foobar', GlobalID.app
     assert_equal 1.year, SignedGlobalID.expires_in
   end
+
+  test 'config.global_id can be used to explicitly set SignedGlobalID.expires_in to nil after the railtie has been loaded' do
+    @app.config.eager_load = true
+    @app.config.before_eager_load do
+      @app.config.global_id.expires_in = nil
+    end
+
+    @app.initialize!
+    assert_nil SignedGlobalID.expires_in
+  end
+
 
   test 'SignedGlobalID.verifier defaults to Blog::Application.message_verifier(:signed_global_ids) when secret_key_base is present' do
     @app.initialize!


### PR DESCRIPTION
This makes it possible to turn off expiration globally.

Closes #127.