### PR TITLE
Add custom class loader strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,35 @@ end
 After defining locators as above, URIs like "gid://foo/Person/1" and "gid://bar/Person/1" will now use the foo block locator and `BarLocator` respectively.
 Other apps will still keep using the default locator.
 
+### Custom Class Loader strategy
+
+By default the class loader just try to constantize the name:
+
+```ruby
+GlobalID.class_loader_strategy = -> (model_name) { model_name.constantize }
+```
+
+To define a custom class loader, you can assign the `class_loader_strategy`:
+
+```ruby
+GlobalID.class_loader_strategy = lambda (model_name) do
+  nested_model = model_name.split('::').last.to_sym
+  if Object.constants.include?(nested_model)
+    Kernel.const_get(nested_model)
+  else
+    model_name.constantize
+  end
+end
+```
+
+The sample class loader above will check nested model name first:
+
+```ruby
+GlobalID.parse('gid://bar/Foo::Bar::Person/5').model_class # => Person
+GlobalID.parse('gid://bar/Bar::Person/5').model_class # => Person
+GlobalID.parse('gid://bar/Person/5').model_class # => Person
+```
+
 ## Contributing to GlobalID
 
 GlobalID is work of many contributors. You're encouraged to submit pull requests, propose

--- a/lib/global_id/global_id.rb
+++ b/lib/global_id/global_id.rb
@@ -33,6 +33,12 @@ class GlobalID
       @app = URI::GID.validate_app(app)
     end
 
+    attr_writer :class_loader_strategy
+
+    def class_loader_strategy
+      @class_loader_strategy ||= ->(model_name) { model_name.constantize }
+    end
+
     private
       def parse_encoded_gid(gid, options)
         new(Base64.urlsafe_decode64(repad_gid(gid)), options) rescue nil
@@ -57,7 +63,11 @@ class GlobalID
   end
 
   def model_class
-    model_name.constantize
+    model_class_for(model_name)
+  end
+
+  def model_class_for(model_name)
+    self.class.class_loader_strategy.call(model_name)
   end
 
   def ==(other)


### PR DESCRIPTION
Testing the custom locators, we missed a way to redefining classes and boundaries while moving parts of our system to external services. Let's say I have the `main` app and I created a new service `child` to start moving part of the domain there.

So, I start with some `gid://main/Child::Person/:id`, but now we're moving the `child` service, so, my new gid will be like `gid://child/Person/:id` and I still need to hand it over the time.

Implementing the custom locator works partially because [find_allowed](https://github.com/rails/globalid/blob/6cdb13f9f5c526498d281b1079c5dcae0f87fcd8/lib/global_id/locator.rb#L17) tries to `constantize` the `model_name` before calls the locator even I don't have any rules there.