### PR TITLE
Remove reference to AS::Concern from GlobalID::Identification

### DIFF
--- a/lib/global_id/identification.rb
+++ b/lib/global_id/identification.rb
@@ -1,9 +1,5 @@
-require 'active_support/concern'
-
 class GlobalID
   module Identification
-    extend ActiveSupport::Concern
-
     def to_global_id(options = {})
       GlobalID.create(self, options)
     end


### PR DESCRIPTION
We can just safely get rid of `require` and `extend` AS::Concern here in `GlobalID::Identification` since this module never uses (have never used) any `ActiveSupport::Concern` feature.