### PR TITLE
Fix ruby-head support

### DIFF
--- a/lib/global_id/uri/gid.rb
+++ b/lib/global_id/uri/gid.rb
@@ -173,5 +173,9 @@ module URI
       end
   end
 
-  @@schemes['GID'] = GID
+  if respond_to?(:register_scheme)
+    register_scheme('GID', GID)
+  else
+    @@schemes['GID'] = GID
+  end
 end


### PR DESCRIPTION
GlobalID is broken on ruby-head following https://github.com/ruby/uri/pull/26.

The new API is much better anyway.