### PR TITLE
Support parrent matching of `GlobalID` & `GlobalID::URI`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,9 @@ task :default => :test
 
 Rake::TestTask.new do |t|
   t.libs << 'test'
-  t.test_files = FileList['test/cases/**/*_test.rb']
+  t.test_files = FileList.new('test/cases/**/*_test.rb') do |fl|
+    fl.exclude('test/cases/pattern_matching_test.rb') if RUBY_VERSION < '2.7'
+  end
   t.verbose = true
   t.warning = true
 end

--- a/lib/global_id/global_id.rb
+++ b/lib/global_id/global_id.rb
@@ -46,7 +46,7 @@ class GlobalID
   end
 
   attr_reader :uri
-  delegate :app, :model_name, :model_id, :params, :to_s, to: :uri
+  delegate :app, :model_name, :model_id, :params, :to_s, :deconstruct_keys, to: :uri
 
   def initialize(gid, options = {})
     @uri = gid.is_a?(URI::GID) ? gid : URI::GID.parse(gid)

--- a/lib/global_id/uri/gid.rb
+++ b/lib/global_id/uri/gid.rb
@@ -98,6 +98,10 @@ module URI
       "gid://#{app}#{path}#{'?' + query if query}"
     end
 
+    def deconstruct_keys(_keys)
+      {app: app, model_name: model_name, model_id: model_id, params: params}
+    end
+
     protected
       def set_path(path)
         set_model_components(path) unless defined?(@model_name) && @model_id

--- a/test/cases/pattern_matching_test.rb
+++ b/test/cases/pattern_matching_test.rb
@@ -1,0 +1,31 @@
+require 'helper'
+
+class URI::PatternMatchingTest < ActiveSupport::TestCase
+  setup do
+    @gid = URI::GID.parse('gid://bcx/Person/5?hello=worlds&param=value')
+  end
+
+  test 'URI::GID pattern matching' do
+    case @gid
+    in app: 'bcx', model_name: 'Person', model_id: '5', params: { hello: _ => world, param: }
+      assert_equal world, 'worlds'
+    else
+      raise
+    end
+  end
+end
+
+class GlobalIDPatternMatchingTest < ActiveSupport::TestCase
+  setup do
+    @gid = GlobalID.parse('gid://bcx/Person/5?hello=worlds&param=value')
+  end
+
+  test 'GlobalID pattern matching' do
+    case @gid
+    in app: 'bcx', model_name: 'Person', model_id: '5', params: { hello: _ => world, param: }
+      assert_equal world, 'worlds'
+    else
+      raise
+    end
+  end
+end


### PR DESCRIPTION
IMHO would be handy to use it in locators, something like 
```ruby
case gid
in app: 'AppOne', model_name: 'ModelOne'
  AppOneModelOneLocator.call(gid.model_id)
in app: 'AppTwo'
  AppTwoLocator.call(gid.model_name, gid.model_id)
else
  # /shrug
end
```