### PR TITLE
URI::GID: Update #check_scheme, no need to call super

### DIFF
--- a/lib/global_id/uri/gid.rb
+++ b/lib/global_id/uri/gid.rb
@@ -138,7 +138,7 @@ module URI
 
       def check_scheme(scheme)
         if scheme == 'gid'
-          super
+          true
         else
           raise URI::BadURIError, "Not a gid:// URI scheme: #{inspect}"
         end


### PR DESCRIPTION
When instantiating a `GlobalId`, the scheme has to be validated with `check_scheme`. Currently anything other than `"gid"` is invalid, and then if the string used is exactly `"gid"` we call `super` which ends up running some Regex in `URI::Generic#check_scheme`.

This PR is a small optimization - I don't think we need to call `check_scheme`, shouldn't `"gid"` always pass?

Here's the method in `URI::Generic`: https://github.com/ruby/ruby/blob/1e7a2415a4c69aa64c9c2a561197bf9cfc5a91f8/lib/uri/generic.rb#L320-L324