### PR TITLE
prevent double find

### DIFF
--- a/lib/global_id/global_id.rb
+++ b/lib/global_id/global_id.rb
@@ -51,7 +51,11 @@ class GlobalID
   end
 
   def model_class
-    model_name.constantize
+    model =  model_name.constantize
+    if model <= GlobalID
+      raise ArgumentError, "GlobalID and SignedGlobalID cannot be used as model_class."
+    end
+    model
   end
 
   def ==(other)

--- a/lib/global_id/global_id.rb
+++ b/lib/global_id/global_id.rb
@@ -51,11 +51,13 @@ class GlobalID
   end
 
   def model_class
-    model =  model_name.constantize
-    if model <= GlobalID
+    model = model_name.constantize
+
+    unless model <= GlobalID
+      model
+    else
       raise ArgumentError, "GlobalID and SignedGlobalID cannot be used as model_class."
     end
-    model
   end
 
   def ==(other)

--- a/test/cases/global_id_test.rb
+++ b/test/cases/global_id_test.rb
@@ -177,6 +177,9 @@ class GlobalIDCreationTest < ActiveSupport::TestCase
     assert_equal Person, @person_uuid_gid.model_class
     assert_equal Person::Child, @person_namespaced_gid.model_class
     assert_equal PersonModel, @person_model_gid.model_class
+    assert_raise ArgumentError do
+      person_gid = GlobalID.find 'gid://bcx/SignedGlobalID/5'
+    end
   end
 
   test ':app option' do


### PR DESCRIPTION
GlobalID and SignedGlobalID themselves have a `.find` method, so they can be specified as a model.
SignedGlobalID is in danger of unexpected RCE if secret_key_base is compromised because Marshal is used internally.
This pull request prevents GlobalID and SignedGlobalID from being targeted.