### PR TITLE
JSON-encode `GlobalID`s as strings

### DIFF
--- a/lib/global_id/global_id.rb
+++ b/lib/global_id/global_id.rb
@@ -66,4 +66,8 @@ class GlobalID
   def to_param
     Base64.urlsafe_encode64(to_s, padding: false)
   end
+
+  def as_json(*)
+    to_s
+  end
 end

--- a/test/cases/global_id_test.rb
+++ b/test/cases/global_id_test.rb
@@ -158,6 +158,20 @@ class GlobalIDCreationTest < ActiveSupport::TestCase
     assert_equal URI('gid://bcx/PersonModel/1'), @person_model_gid.uri
   end
 
+  test 'as JSON' do
+    assert_equal 'gid://bcx/Person/5', @person_gid.as_json
+    assert_equal '"gid://bcx/Person/5"', @person_gid.to_json
+
+    assert_equal "gid://bcx/Person/#{@uuid}", @person_uuid_gid.as_json
+    assert_equal "\"gid://bcx/Person/#{@uuid}\"", @person_uuid_gid.to_json
+
+    assert_equal 'gid://bcx/Person::Child/4', @person_namespaced_gid.as_json
+    assert_equal '"gid://bcx/Person::Child/4"', @person_namespaced_gid.to_json
+
+    assert_equal 'gid://bcx/PersonModel/1', @person_model_gid.as_json
+    assert_equal '"gid://bcx/PersonModel/1"', @person_model_gid.to_json
+  end
+
   test 'model id' do
     assert_equal '5', @person_gid.model_id
     assert_equal @uuid, @person_uuid_gid.model_id


### PR DESCRIPTION
Before:

```ruby
> Plan.last.to_gid.as_json
{"uri"=>"gid://sandbox/Plan/186"}

> Plan.last.to_gid.to_json
"{\"uri\":\"gid://sandbox/Plan/186\"}"
```

After:

```ruby
> Plan.last.to_gid.as_json
"gid://sandbox/Plan/186"

> Plan.last.to_gid.to_json
"\"gid://sandbox/Plan/186\""
```

This is particularly useful for JSON-serialized attributes in Rails, which use the result of `#as_json` on assigned values to generate the JSON they store.

```ruby
class SubscriptionChange < ApplicationRecord
  serialize :old_product_gids, JSON
end
```

Before:

```ruby
> SubscriptionChange.create!(old_product_gids: [ Plan.last.to_gid ]).old_product_gids
# => [{ "uri" => "gid://sandbox/Plan/186" }]
```

After:

```ruby
> SubscriptionChange.create!(old_product_gids: [ Plan.last.to_gid ]).old_product_gids
# => [ "gid://sandbox/Plan/186" ]
```