### PR TITLE
Remove test_order method check in test/helper.rb

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,11 +9,6 @@ require 'models/person_model'
 
 require 'json'
 
-if ActiveSupport::TestCase.respond_to?(:test_order=)
-  # TODO: remove check once ActiveSupport dependency is at least 4.2
-  ActiveSupport::TestCase.test_order = :random
-end
-
 GlobalID.app = 'bcx'
 
 # Default serializers is Marshal, whose format changed 1.9 -> 2.0,


### PR DESCRIPTION
* currently globalid is depending on 'activesupport >= 5.0', which makes the `ActiveSupport::TestCase.respond_to?(:test_order=)` check redundant
* in 'activesupport > 4.1.16,  < 5.0' , `ActiveSupport::TestCase.test_order` default to `:sorted`, but in 'activesupport >= 5.0', its default is `:random`, so these thress lines of code can be removed

ref: 
* [rails/test\_case.rb at v4.1.16 · rails/rails](https://github.com/rails/rails/blob/v4.1.16/activesupport/lib/active_support/test_case.rb)
* [rails/test\_case.rb at v4.2.0 · rails/rails](https://github.com/rails/rails/blob/v4.2.0/activesupport/lib/active_support/test_case.rb)
* [rails/test\_case.rb at v5.0.0 · rails/rails](https://github.com/rails/rails/blob/v5.0.0/activesupport/lib/active_support/test_case.rb)
* [rails/test\_case.rb at v7.0.0 · rails/rails](https://github.com/rails/rails/blob/v7.0.0/activesupport/lib/active_support/test_case.rb)