### PR TITLE
Drop support to Rails < 6.1 and unsupported Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ 2.5, 2.6, 2.7 ]
-        rails: [ '5.0', '5.1', '5.2', '6.0', '6.1' ]
+        rails: [ '5.2', '6.0', '6.1' ]
         include:
           - ruby: '2.7'
             rails: '7.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,44 +6,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7 ]
-        rails: [ '5.2', '6.0', '6.1' ]
+        ruby: [ '2.7', '3.0', '3.1', 'head', 'truffleruby' ]
+        rails: [ '6.1', '7.0', 'main' ]
         include:
-          - ruby: '2.7'
-            rails: '7.0'
-          - ruby: '2.7'
-            rails: 'main'
-          - ruby: '3.0'
-            rails: '6.0'
-          - ruby: '3.0'
-            rails: '6.1'
-          - ruby: '3.0'
-            rails: '7.0'
-          - ruby: '3.0'
-            rails: 'main'
-          - ruby: '3.1'
-            rails: '6.1'
-          - ruby: '3.1'
-            rails: '7.0'
-          - ruby: '3.1'
-            rails: 'main'
           - ruby: '3.2'
             rails: '7.0'
           - ruby: '3.2'
-            rails: 'main'
-          - ruby: head
-            rails: '6.0'
-          - ruby: head
-            rails: '6.1'
-          - ruby: head
-            rails: 'main'
-          - ruby: truffleruby
-            rails: '6.0'
-          - ruby: truffleruby
-            rails: '6.1'
-          - ruby: truffleruby
-            rails: '7.0'
-          - ruby: truffleruby
             rails: 'main'
 
     env:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     globalid (1.1.0)
-      activesupport (>= 5.2)
+      activesupport (>= 6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     globalid (1.1.0)
-      activesupport (>= 5.0)
+      activesupport (>= 5.2)
 
 GEM
   remote: https://rubygems.org/

--- a/Rakefile
+++ b/Rakefile
@@ -5,9 +5,7 @@ task :default => :test
 
 Rake::TestTask.new do |t|
   t.libs << 'test'
-  t.test_files = FileList.new('test/cases/**/*_test.rb') do |fl|
-    fl.exclude('test/cases/pattern_matching_test.rb') if RUBY_VERSION < '2.7'
-  end
+  t.test_files = FileList['test/cases/**/*_test.rb']
   t.verbose = true
   t.warning = true
 end

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -1,7 +1,0 @@
-source "https://rubygems.org"
-
-gem "activemodel", "~> 5.0.0"
-gem "railties", "~> 5.0.0"
-gem "minitest", "~> 5.10.0"
-
-gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gem "activemodel", "~> 5.1.0"
-gem "railties", "~> 5.1.0"
-
-gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gem "activemodel", "~> 5.2.0"
-gem "railties", git: "https://github.com/rails/rails", branch: "5-2-stable"
-
-gemspec path: "../"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gem "activemodel", "~> 6.0.0"
-gem "railties", "~> 6.0.0"
-
-gemspec path: "../"

--- a/globalid.gemspec
+++ b/globalid.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files        = Dir['MIT-LICENSE', 'README.md', 'lib/**/*']
   s.require_path = 'lib'
 
-  s.add_runtime_dependency 'activesupport', '>= 5.0'
+  s.add_runtime_dependency 'activesupport', '>= 5.2'
 
   s.add_development_dependency 'rake'
 

--- a/globalid.gemspec
+++ b/globalid.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files        = Dir['MIT-LICENSE', 'README.md', 'lib/**/*']
   s.require_path = 'lib'
 
-  s.add_runtime_dependency 'activesupport', '>= 5.2'
+  s.add_runtime_dependency 'activesupport', '>= 6.1'
 
   s.add_development_dependency 'rake'
 


### PR DESCRIPTION
Only Rails >= 6.1 and Ruby >= 2.7 are supported now following the maintenance policy of the framework and the language.