### PR TITLE
Don't show secrets for SignedGlobalID#inspect

### DIFF
--- a/lib/global_id/signed_global_id.rb
+++ b/lib/global_id/signed_global_id.rb
@@ -72,6 +72,10 @@ class SignedGlobalID < GlobalID
     super && @purpose == other.purpose
   end
 
+  def inspect # :nodoc:
+    "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
+  end
+
   private
     def pick_expiration(options)
       return options[:expires_at] if options.key?(:expires_at)

--- a/test/cases/signed_global_id_test.rb
+++ b/test/cases/signed_global_id_test.rb
@@ -29,6 +29,10 @@ class SignedGlobalIDTest < ActiveSupport::TestCase
   test 'to param' do
     assert_equal @person_sgid.to_s, @person_sgid.to_param
   end
+
+  test 'inspect' do
+    assert_match(/\A#<SignedGlobalID:0x[0-9a-f]+>\z/, @person_sgid.inspect)
+  end
 end
 
 class SignedGlobalIDPurposeTest < ActiveSupport::TestCase


### PR DESCRIPTION
If anyone calls `to_sgid` on a model in the console it will show the secret of the encryptor.

By overriding the `inspect` method to only show the class name we can avoid accidentally outputting sensitive information.

Before:

```ruby
SignedGlobalID.create(Person.new(5)).inspect
"#<SignedGlobalID:0x0000000104888038 ... @secret=\"muchSECRETsoHIDDEN\ ... >"
```

After:

```ruby
SignedGlobalID.create(Person.new(5)).inspect
"#<SignedGlobalID:0x0000000104888038>"
```