### PR TITLE
Allow for composite identifiers delimited by `/`

### DIFF
--- a/lib/global_id/global_id.rb
+++ b/lib/global_id/global_id.rb
@@ -50,12 +50,13 @@ class GlobalID
   end
 
   def model_class
-    model = model_name.constantize
+    @model_class ||= begin
+      model = model_name.constantize
 
-    unless model <= GlobalID
+      if model <= GlobalID
+        raise ArgumentError, "GlobalID and SignedGlobalID cannot be used as model_class."
+      end
       model
-    else
-      raise ArgumentError, "GlobalID and SignedGlobalID cannot be used as model_class."
     end
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,6 +6,7 @@ require 'active_support/testing/autorun'
 require 'global_id'
 require 'models/person'
 require 'models/person_model'
+require 'models/composite_primary_key_model'
 
 require 'json'
 

--- a/test/models/composite_primary_key_model.rb
+++ b/test/models/composite_primary_key_model.rb
@@ -1,0 +1,42 @@
+require 'active_model'
+
+class CompositePrimaryKeyModel
+  include ActiveModel::Model
+  include GlobalID::Identification
+
+  attr_accessor :id
+
+  def self.primary_key
+    [:tenant_key, :id]
+  end
+
+  def self.find(id_or_ids)
+    raise "id is not composite" unless id_or_ids.is_a?(Array)
+    multi_record_fetch = id_or_ids.first.is_a?(Array)
+    if multi_record_fetch
+      id_or_ids.map do |id|
+        raise "id doesn't match primary key #{primary_key}" if id.size != primary_key.size
+        new id: id
+      end
+    else
+      raise "id doesn't match primary key #{primary_key}" if id_or_ids.size != primary_key.size
+      new id: id_or_ids
+    end
+  end
+
+  def where(conditions)
+    keys = conditions.keys
+    raise "only primary key condition was expected" if keys.size != 1
+    pk = keys.first
+    raise "key is not the `#{primary_key}` primary key" if pk != primary_key
+
+    conditions[pk].map do |id|
+      raise "id doesn't match primary key #{primary_key}" if id.size != primary_key.size
+      new id: id
+    end
+  end
+
+  def ==(other)
+    id == other.try(:id)
+  end
+end

--- a/test/models/person.rb
+++ b/test/models/person.rb
@@ -5,6 +5,10 @@ class Person
 
   attr_reader :id
 
+  def self.primary_key
+    :id
+  end
+
   def self.find(id_or_ids)
     if id_or_ids.is_a? Array
       ids = id_or_ids

--- a/test/models/person_model.rb
+++ b/test/models/person_model.rb
@@ -6,6 +6,10 @@ class PersonModel
 
   attr_accessor :id
 
+  def self.primary_key
+    :id
+  end
+
   def self.find(id)
     new id: id
   end


### PR DESCRIPTION
This commit extends global id to allow representing models with composite identifiers. The value will be joined by `/`. For example:

Given a `TravelRoute` model with `origin` and `destination` as the compsoite primary key, the global id will be represented as:

```
TravelRoute.new(origin: "Ottawa", destination: "New York").to_global_id
# => gid://app/TravelRoute/Ottawa/New%20York
```

### Context

Next version of Rails will support models with a composite primary key and globalid need to provide capabilities to present such models. One of the major use-cases is the Active Record objects serialization in Active Job jobs

### Major changes

- Default locator now enforces models to implement `primary_key` class method

### Choosing the delimiter

We end up choosing `/` as a delimiter since it has the least change of conflicting with one of the values of the composite primary key. However it leads to slightly changed semantic when it comes to splitting the segments of the gid
For example a broken URI like `'gid://app/alsoapp/Person/12'` used to considered invalid due to malformed app name. But now the same URI will be parsed as:
```
app - app name
alsoapp - model name
Person/12 - composite model id
```

Basically this is the only concern with the `/` being used as a delimiter

As an alternative we were considering `_` to serve as a delimiter but since the delimiter value is going to be hardcoded we decided against it as it has a higher chance of conflicting with the actual value of the composite key

### What reviewers should be focusing on

a global id like `'gid://app/Person/1/2'` used to be considered invalid. After the change it will be possible to parse and initialize an `URI::GID` instance and `1/2` will be parsed as `['1','2']` composite key however it won't be possible to look up records using `GlobalID` instance created from such `URI::GID` 

To prevent malicious actors from crafting gids with unrealistically long composite keys we have limited the maximum size of the composite key by `20`
This has been done to prevent issues like https://github.com/advisories/GHSA-23c2-gwp5-pxw9 


### Integration test

Here is a script that tests changes in integration with Active Job

<details>
  <summary>Expand</summary>
  
  
  ```ruby
    # frozen_string_literal: true

    require "bundler/inline"

    gemfile(true) do
      source "https://rubygems.org"

      git_source(:github) { |repo| "https://github.com/#{repo}.git" }

      gem "rails", github: "rails/rails", branch: "main"
      gem "globalid", github: "Shopify/globalid", branch: "ac-gid-cpk"
      gem "sqlite3"
    end

    require "active_job"
    require "active_record"
    require "minitest/autorun"

    # This connection will do for database-independent bug reports.
    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
    ActiveRecord::Base.logger = Logger.new(STDOUT)

    ActiveRecord::Schema.define do
      create_table :orders, force: true do |t|
        t.integer :shop_id
        t.string :name
      end

      create_table :events, force: true do |t|
        t.string :name
        t.text :data
      end
    end

    GlobalID.app = "demo"

    class Order < ActiveRecord::Base
      include GlobalID::Identification
      self.primary_key = [:shop_id, :id]
    end

    class Event < ActiveRecord::Base
      serialize :data, Hash
    end

    class CpkJob < ActiveJob::Base
      def perform(order:)
        Event.create(name: "order processed", data: {id_value: order.id_value, shop_id: order.shop_id, name: order.name})
      end
    end

    class CpkJobTest < ActiveJob::TestCase
      def test_stuff
        CpkJob.perform_later(order: Order.create(id: [123, 1], name: "serialized as a gid"))
        perform_enqueued_jobs

        assert_equal 1, Event.count
        event = Event.first
        assert_equal "order processed", event.name
        assert_equal({id_value: 1, shop_id: 123, name: "serialized as a gid"}, event.data)
      end
    end

  ```
  
</details>



