### PR TITLE
[Tests only] Add `Locator#locate_many` tests for non `id` primary keys

### DIFF
--- a/test/cases/global_id_test.rb
+++ b/test/cases/global_id_test.rb
@@ -41,7 +41,7 @@ class GlobalIDCreationTest < ActiveSupport::TestCase
   setup do
     @uuid = '7ef9b614-353c-43a1-a203-ab2307851990'
     @person_gid = GlobalID.create(Person.new(5))
-    @person_uuid_gid = GlobalID.create(Person.new(@uuid))
+    @person_uuid_gid = GlobalID.create(PersonUuid.new(@uuid))
     @person_namespaced_gid = GlobalID.create(Person::Child.new(4))
     @person_model_gid = GlobalID.create(PersonModel.new(id: 1))
     @cpk_model_gid = GlobalID.create(CompositePrimaryKeyModel.new(id: ["tenant-key-value", "id-value"]))
@@ -136,7 +136,7 @@ class GlobalIDCreationTest < ActiveSupport::TestCase
 
   test 'as string' do
     assert_equal 'gid://bcx/Person/5', @person_gid.to_s
-    assert_equal "gid://bcx/Person/#{@uuid}", @person_uuid_gid.to_s
+    assert_equal "gid://bcx/PersonUuid/#{@uuid}", @person_uuid_gid.to_s
     assert_equal 'gid://bcx/Person::Child/4', @person_namespaced_gid.to_s
     assert_equal 'gid://bcx/PersonModel/1', @person_model_gid.to_s
     assert_equal 'gid://bcx/CompositePrimaryKeyModel/tenant-key-value/id-value', @cpk_model_gid.to_s
@@ -146,8 +146,8 @@ class GlobalIDCreationTest < ActiveSupport::TestCase
     assert_equal 'Z2lkOi8vYmN4L1BlcnNvbi81', @person_gid.to_param
     assert_equal @person_gid, GlobalID.parse('Z2lkOi8vYmN4L1BlcnNvbi81')
 
-    assert_equal 'Z2lkOi8vYmN4L1BlcnNvbi83ZWY5YjYxNC0zNTNjLTQzYTEtYTIwMy1hYjIzMDc4NTE5OTA', @person_uuid_gid.to_param
-    assert_equal @person_uuid_gid, GlobalID.parse('Z2lkOi8vYmN4L1BlcnNvbi83ZWY5YjYxNC0zNTNjLTQzYTEtYTIwMy1hYjIzMDc4NTE5OTA')
+    assert_equal 'Z2lkOi8vYmN4L1BlcnNvblV1aWQvN2VmOWI2MTQtMzUzYy00M2ExLWEyMDMtYWIyMzA3ODUxOTkw', @person_uuid_gid.to_param
+    assert_equal @person_uuid_gid, GlobalID.parse('Z2lkOi8vYmN4L1BlcnNvblV1aWQvN2VmOWI2MTQtMzUzYy00M2ExLWEyMDMtYWIyMzA3ODUxOTkw')
 
     assert_equal 'Z2lkOi8vYmN4L1BlcnNvbjo6Q2hpbGQvNA', @person_namespaced_gid.to_param
     assert_equal @person_namespaced_gid, GlobalID.parse('Z2lkOi8vYmN4L1BlcnNvbjo6Q2hpbGQvNA')
@@ -162,7 +162,7 @@ class GlobalIDCreationTest < ActiveSupport::TestCase
 
   test 'as URI' do
     assert_equal URI('gid://bcx/Person/5'), @person_gid.uri
-    assert_equal URI("gid://bcx/Person/#{@uuid}"), @person_uuid_gid.uri
+    assert_equal URI("gid://bcx/PersonUuid/#{@uuid}"), @person_uuid_gid.uri
     assert_equal URI('gid://bcx/Person::Child/4'), @person_namespaced_gid.uri
     assert_equal URI('gid://bcx/PersonModel/1'), @person_model_gid.uri
     assert_equal URI('gid://bcx/CompositePrimaryKeyModel/tenant-key-value/id-value'), @cpk_model_gid.uri
@@ -172,8 +172,8 @@ class GlobalIDCreationTest < ActiveSupport::TestCase
     assert_equal 'gid://bcx/Person/5', @person_gid.as_json
     assert_equal '"gid://bcx/Person/5"', @person_gid.to_json
 
-    assert_equal "gid://bcx/Person/#{@uuid}", @person_uuid_gid.as_json
-    assert_equal "\"gid://bcx/Person/#{@uuid}\"", @person_uuid_gid.to_json
+    assert_equal "gid://bcx/PersonUuid/#{@uuid}", @person_uuid_gid.as_json
+    assert_equal "\"gid://bcx/PersonUuid/#{@uuid}\"", @person_uuid_gid.to_json
 
     assert_equal 'gid://bcx/Person::Child/4', @person_namespaced_gid.as_json
     assert_equal '"gid://bcx/Person::Child/4"', @person_namespaced_gid.to_json
@@ -195,7 +195,7 @@ class GlobalIDCreationTest < ActiveSupport::TestCase
 
   test 'model name' do
     assert_equal 'Person', @person_gid.model_name
-    assert_equal 'Person', @person_uuid_gid.model_name
+    assert_equal 'PersonUuid', @person_uuid_gid.model_name
     assert_equal 'Person::Child', @person_namespaced_gid.model_name
     assert_equal 'PersonModel', @person_model_gid.model_name
     assert_equal 'CompositePrimaryKeyModel', @cpk_model_gid.model_name
@@ -203,7 +203,7 @@ class GlobalIDCreationTest < ActiveSupport::TestCase
 
   test 'model class' do
     assert_equal Person, @person_gid.model_class
-    assert_equal Person, @person_uuid_gid.model_class
+    assert_equal PersonUuid, @person_uuid_gid.model_class
     assert_equal Person::Child, @person_namespaced_gid.model_class
     assert_equal PersonModel, @person_model_gid.model_class
     assert_equal CompositePrimaryKeyModel, @cpk_model_gid.model_class

--- a/test/cases/global_locator_test.rb
+++ b/test/cases/global_locator_test.rb
@@ -6,6 +6,7 @@ class GlobalLocatorTest < ActiveSupport::TestCase
     @gid  = model.to_gid
     @sgid = model.to_sgid
     @cpk_model = CompositePrimaryKeyModel.new(id: ["tenant-key-value", "id-value"])
+    @uuid_pk_model = PersonUuid.new('7ef9b614-353c-43a1-a203-ab2307851990')
     @cpk_gid = @cpk_model.to_gid
     @cpk_sgid = @cpk_model.to_sgid
   end
@@ -84,6 +85,17 @@ class GlobalLocatorTest < ActiveSupport::TestCase
   test 'by many GIDs of one class' do
     assert_equal [ Person.new('1'), Person.new('2') ],
       GlobalID::Locator.locate_many([ Person.new('1').to_gid, Person.new('2').to_gid ])
+  end
+
+  test 'by many GIDs of a UUID pk class' do
+    expected = [ @uuid_pk_model, @uuid_pk_model ]
+    assert_equal expected, GlobalID::Locator.locate_many(expected.map(&:to_gid))
+  end
+
+  test 'by many GIDs of a UUID pk class with ignore missing' do
+    gids_to_locate = [ @uuid_pk_model, PersonUuid.new(Person::HARDCODED_ID_FOR_MISSING_PERSON), @uuid_pk_model ]
+    expected = [ @uuid_pk_model, @uuid_pk_model ]
+    assert_equal expected, GlobalID::Locator.locate_many(gids_to_locate.map(&:to_gid), ignore_missing: true)
   end
 
   test '#locate_many by composite primary key GIDs of the same class' do

--- a/test/models/person.rb
+++ b/test/models/person.rb
@@ -25,7 +25,7 @@ class Person
   end
 
   def self.where(conditions)
-    (conditions[:id] - [HARDCODED_ID_FOR_MISSING_PERSON]).collect { |id| new(id) }
+    (conditions[primary_key] - [HARDCODED_ID_FOR_MISSING_PERSON]).collect { |id| new(id) }
   end
 
   def initialize(id = 1)
@@ -34,6 +34,12 @@ class Person
 
   def ==(other)
     other.is_a?(self.class) && id == other.try(:id)
+  end
+end
+
+class PersonUuid < Person
+  def self.primary_key
+    :uuid
   end
 end
 


### PR DESCRIPTION
`locate_many` with `ignore_missing: true` used to be broken due to to `id: values` clause being hardcoded 

https://github.com/rails/globalid/blob/5c68d15e97fb3dd10ac406669d5ab62018e7894c/lib/global_id/locator.rb#L145

We changed it in https://github.com/rails/globalid/pull/163 which made it possible to fully support non-`id` named primary keys in `locate_many`

https://github.com/rails/globalid/blob/5ce154c0eaacdde7ce86e781a25336e000db316f/lib/global_id/locator.rb#L161