### PR TITLE
Don't break on models where `primary_key` is not defined

### DIFF
--- a/lib/global_id/locator.rb
+++ b/lib/global_id/locator.rb
@@ -190,14 +190,18 @@ class GlobalID
             model_class = model_class.includes(options[:includes]) if options[:includes]
 
             if options[:ignore_missing]
-              model_class.where(model_class.primary_key => ids)
+              model_class.where(primary_key(model_class) => ids)
             else
               model_class.find(ids)
             end
           end
 
           def model_id_is_valid?(gid)
-            Array(gid.model_id).size == Array(gid.model_class.primary_key).size
+            Array(gid.model_id).size == Array(primary_key(gid.model_class)).size
+          end
+
+          def primary_key(model_class)
+            model_class.respond_to?(:primary_key) ? model_class.primary_key : :id
           end
       end
 

--- a/test/cases/global_locator_test.rb
+++ b/test/cases/global_locator_test.rb
@@ -369,6 +369,23 @@ class GlobalLocatorTest < ActiveSupport::TestCase
     end
   end
 
+  test 'by GID without a primary key method' do
+    model = PersonWithoutPrimaryKey.new('id')
+    gid = model.to_gid
+    model2 = PersonWithoutPrimaryKey.new('id2')
+    gid2 = model.to_gid
+
+    found = GlobalID::Locator.locate(gid)
+    assert_kind_of model.class, found
+    assert_equal 'id', found.id
+
+    found = GlobalID::Locator.locate_many([gid, gid2])
+    assert_equal 2, found.length
+
+    found = GlobalID::Locator.locate_many([gid, gid2], ignore_missing: true)
+    assert_equal 2, found.length
+  end
+
   private
     def with_app(app)
       old_app, GlobalID.app = GlobalID.app, app

--- a/test/models/person.rb
+++ b/test/models/person.rb
@@ -101,3 +101,27 @@ class Person::Child < Person
     other.is_a?(self.class) && id == other.try(:id) && parent == other.parent
   end
 end
+
+class PersonWithoutPrimaryKey
+  include GlobalID::Identification
+
+  attr_reader :id
+
+  def self.find(id_or_ids)
+    if id_or_ids.is_a? Array
+      ids = id_or_ids
+      ids.collect { |id| find(id) }
+    else
+      id = id_or_ids
+      new(id)
+    end
+  end
+
+  def self.where(conditions)
+    (conditions[:id]).collect { |id| new(id) }
+  end
+
+  def initialize(id = 1)
+    @id = id
+  end
+end


### PR DESCRIPTION
https://github.com/rails/globalid/pull/163 introduced these errors into Rails CI: https://buildkite.com/rails/rails/builds/99322#018a5d7e-f556-4966-a32d-904737c65eeb

They are occuring on classes that `include GlobalID::Identification` but are not Active Record subclasses.

There is no explicit GlobalID API identified, but as far as I can tell, the only methods you *need* to implement are `self.find`, `self.where`, and `id`. So this PR ensures that we don't break support for classes that don't implement `primary_key`.