### PR TITLE
CONTRIBUTING.md: Use GitHub Actions build status badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ jobs:
       matrix:
         ruby: [ '2.7', '3.0', '3.1', '3.2', 'head', 'truffleruby' ]
         rails: [ '6.1', '7.0', 'main' ]
+        exclude:
+          - ruby: '2.7'
+            rails: 'main'
+          - ruby: '3.0'
+            rails: 'main'
         include:
           - ruby: '3.2'
             rails: '7.0'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Contributing to GlobalID
 =====================
 
-[![Build Status](https://secure.travis-ci.org/rails/globalid.png)](https://travis-ci.org/rails/globalid)
+[![CI](https://github.com/rails/globalid/actions/workflows/ci.yml/badge.svg)](https://github.com/rails/globalid/actions/workflows/ci.yml)
 
 GlobalID is work of [many contributors](https://github.com/rails/globalid/graphs/contributors). You're encouraged to submit [pull requests](https://github.com/rails/globalid/pulls), [propose features and discuss issues](https://github.com/rails/globalid/issues).
 


### PR DESCRIPTION
This PR swaps out the Travis build status badge for a GitHub Actions one.

EDIT: In order to make the test suite pass, I added a matrix exclude for "Ruby 2.7, Ruby 3.0 on Rails main". 🟢 This got us **to green**.