### PR TITLE
Add GlobalId::Identification::build_global_id

### DIFF
--- a/lib/global_id/identification.rb
+++ b/lib/global_id/identification.rb
@@ -46,6 +46,40 @@ class GlobalID
       def global_id_app=(app)
         self._global_id_app = URI::GID.validate_app(app)
       end
+
+      # Build a Global ID from the given object.
+      #
+      # If the object responds to `to_global_id` it will return the result of that call.
+      #   Person.build_global_id(Person.find(1)) # => #<GlobalID:0x000000012b7dcea0 @uri=#<URI::GID gid://app/Person/1>>
+      # If the object is a string or an integer, it will build a GlobalID using that object.
+      #   Person.build_global_id(1) # => #<GlobalID:0x000000012b7dcea0 @uri=#<URI::GID gid://app/Person/1>>
+      # If the object is not a string or an integer, it will raise an ArgumentError.
+      #   Person.build_global_id(Person) # => ArgumentError: Can't build a Global ID for Class
+      #
+      # An app is required to create a GlobalID. Pass the :app option or set the default GlobalID.app.
+      def build_global_id(obj, options = {})
+        return obj.to_global_id(options) if obj.respond_to?(:to_global_id)
+        raise ArgumentError, "Can't build a Global ID for #{obj.class}" unless obj.is_a?(String) || obj.is_a?(Integer)
+
+        new(id: obj).to_global_id(options)
+      end
+
+      # Build a Signed Global ID from the given object.
+      #
+      # If the object responds to `to_signed_global_id` it will return the result of that call.
+      #   Person.build_signed_global_id(Person.find(1)) # => <SignedGlobalID:0x008fde45df8937 ...>
+      # If the object is a string or an integer, it will build a GlobalID using that object.
+      #   Person.build_signed_global_id(1) # => <SignedGlobalID:0x008fde45df8937 ...>
+      # If the object is not a string or an integer, it will raise an ArgumentError.
+      #   Person.build_signed_global_id(Person) # => ArgumentError: Can't build a Signed Global ID for Class
+      #
+      # An app is required to create a SignedGlobalID. Pass the :app option or set the default GlobalID.app.
+      def build_signed_global_id(obj, options = {})
+        return obj.to_signed_global_id(options) if obj.respond_to?(:to_signed_global_id)
+        raise ArgumentError, "Can't build a Signed Global ID for #{obj.class}" unless obj.is_a?(String) || obj.is_a?(Integer)
+
+        new(id: obj).to_signed_global_id(options)
+      end
     end
 
     # Returns the Global ID of the model.

--- a/test/cases/global_identification_test.rb
+++ b/test/cases/global_identification_test.rb
@@ -9,11 +9,15 @@ class GlobalIdentificationTest < ActiveSupport::TestCase
   test 'creates a Global ID from self' do
     assert_equal GlobalID.create(@model), @model.to_global_id
     assert_equal GlobalID.create(@model), @model.to_gid
+    assert_equal PersonModel.build_global_id(@model), @model.to_gid
+    assert_equal PersonModel.build_global_id(1), @model.to_global_id
   end
 
   test 'creates a Global ID with custom params' do
     assert_equal GlobalID.create(@model, some: 'param'), @model.to_global_id(some: 'param')
     assert_equal GlobalID.create(@model, some: 'param'), @model.to_gid(some: 'param')
+    assert_equal PersonModel.build_global_id(@model, some: 'param'), @model.to_gid(some: 'param')
+    assert_equal PersonModel.build_global_id(1, some: 'param'), @model.to_global_id(some: 'param')
   end
 
   test 'creates a Global ID with a custom app' do
@@ -22,27 +26,35 @@ class GlobalIdentificationTest < ActiveSupport::TestCase
     assert_equal GlobalID.create(model, app: 'custom-app'), model.to_global_id
     assert_equal GlobalID.create(model, app: 'custom-app'), model.to_gid
     assert_equal GlobalID.create(model, app: 'other-app'), model.to_global_id(app: 'other-app')
+    assert_equal GlobalID.create(model, app: 'custom-app'), CustomAppPersonModel.build_global_id(1)
   end
 
   test 'to_gid delegates to overridden to_global_id' do
     model = OverriddenToGlobalIDPersonModel.new id: 1
 
     assert_equal GlobalID.create(model, app: 'override-app'), model.to_gid
+    assert_equal GlobalID.create(model, app: 'override-app'), OverriddenToGlobalIDPersonModel.build_global_id(1)
   end
 
   test 'creates a signed Global ID from self' do
     assert_equal SignedGlobalID.create(@model), @model.to_signed_global_id
     assert_equal SignedGlobalID.create(@model), @model.to_sgid
+    assert_equal PersonModel.build_signed_global_id(@model), @model.to_sgid
+    assert_equal PersonModel.build_signed_global_id(1), @model.to_signed_global_id
   end
 
   test 'creates a signed Global ID with purpose ' do
     assert_equal SignedGlobalID.create(@model, for: 'login'), @model.to_signed_global_id(for: 'login')
     assert_equal SignedGlobalID.create(@model, for: 'login'), @model.to_sgid(for: 'login')
+    assert_equal PersonModel.build_signed_global_id(@model, for: 'login'), @model.to_sgid(for: 'login')
+    assert_equal PersonModel.build_signed_global_id(1, for: 'login'), @model.to_signed_global_id(for: 'login')
   end
 
   test 'creates a signed Global ID with custom params' do
     assert_equal SignedGlobalID.create(@model, some: 'param'), @model.to_signed_global_id(some: 'param')
     assert_equal SignedGlobalID.create(@model, some: 'param'), @model.to_sgid(some: 'param')
+    assert_equal PersonModel.build_signed_global_id(@model, some: 'param'), @model.to_sgid(some: 'param')
+    assert_equal PersonModel.build_signed_global_id(1, some: 'param'), @model.to_signed_global_id(some: 'param')
   end
 
   test 'creates a signed Global ID with a custom app' do
@@ -50,6 +62,12 @@ class GlobalIdentificationTest < ActiveSupport::TestCase
 
     assert_equal SignedGlobalID.create(model, app: 'custom-app').to_s, model.to_signed_global_id.to_s
     assert_equal SignedGlobalID.create(model, app: 'custom-app').to_s, model.to_sgid.to_s
+    assert_equal SignedGlobalID.create(model, app: 'custom-app'), CustomAppPersonModel.build_signed_global_id(1)
+  end
+
+  test "doesn't create a Global ID if ID is not valid" do
+    assert_raises(ArgumentError) { PersonModel.build_global_id(PersonModel) }
+    assert_raises(ArgumentError) { PersonModel.build_signed_global_id(PersonModel) }
   end
 
   test 'dup should clear memoized to_global_id' do
@@ -66,7 +84,7 @@ class CustomAppPersonModel < PersonModel
 end
 
 class OverriddenToGlobalIDPersonModel < PersonModel
-  def to_global_id(app: 'override-app', **)
-    super
+  def to_global_id(options = {})
+    super(options.merge(app: 'override-app'))
   end
 end


### PR DESCRIPTION
Inspired from #181.

This PR aims to add a class method to the models that'd give an ability build your own GlobalIDs


Example:
```ruby
PersonModel.build_global_id(1) => #<GlobalID:0x000000012b7dcea0 @uri=#<URI::GID gid://app/Person/1>>
```