### PR TITLE
Move uri parser to constant

### DIFF
--- a/lib/global_id/uri/gid.rb
+++ b/lib/global_id/uri/gid.rb
@@ -36,6 +36,8 @@ module URI
     COMPOSITE_MODEL_ID_MAX_SIZE = 20
     COMPOSITE_MODEL_ID_DELIMITER = "/"
 
+    URI_PARSER = URI::RFC2396_Parser.new # :nodoc:
+
     class << self
       # Validates +app+'s as URI hostnames containing only alphanumeric characters
       # and hyphens. An ArgumentError is raised if +app+ is invalid.
@@ -62,7 +64,7 @@ module URI
       #   URI.parse('gid://bcx')       # => URI::GID instance
       #   URI::GID.parse('gid://bcx/') # => raises URI::InvalidComponentError
       def parse(uri)
-        generic_components = URI.split(uri) << URI::RFC2396_Parser.new << true # RFC2396 parser, true arg_check
+        generic_components = URI.split(uri) << URI_PARSER << true # RFC2396 parser, true arg_check
         new(*generic_components)
       end
 


### PR DESCRIPTION
Followup to https://github.com/rails/globalid/pull/192

Creating a new one each time is horrible for performance:

```rb
require "bundler/inline"

gemfile do
  gem "benchmark-ips"
  gem "globalid", path: "."
end

Benchmark.ips do |x|
  x.report("current") { URI::GID.parse 'gid://bcx/Person/1?key=value' }
  x.report("pr") { URI::GID.parse_from_pr 'gid://bcx/Person/1?key=value' }

  x.compare!
end

$ ruby test.rb
ruby 3.4.5 (2025-07-16 revision 20cda200d3) +PRISM [x86_64-linux]
Warming up --------------------------------------
             current   161.000 i/100ms
                  pr     8.860k i/100ms
Calculating -------------------------------------
             current      1.621k (± 2.2%) i/s  (617.01 μs/i) -      8.211k in   5.068729s
                  pr     93.755k (± 2.2%) i/s   (10.67 μs/i) -    469.580k in   5.011127s

Comparison:
                  pr:    93755.2 i/s
             current:     1620.7 i/s - 57.85x  slower
```