### PR TITLE
Resolve deprecation warning around #locate arity for custom locator test

### DIFF
--- a/test/cases/global_locator_test.rb
+++ b/test/cases/global_locator_test.rb
@@ -388,9 +388,7 @@ class GlobalLocatorTest < ActiveSupport::TestCase
 
   test "can set default_locator" do
     class MyLocator
-      def locate(gid)
-        :my_locator
-      end
+      def locate(gid, options = {}); :my_locator; end
     end
 
     with_default_locator(MyLocator.new) do


### PR DESCRIPTION
I noticed the deprecation warnings from new tests introduced by #179 failing in main, figured i'd knock it out