### PR TITLE
Don't try to constantize GID's class too soon

### DIFF
--- a/lib/global_id/locator.rb
+++ b/lib/global_id/locator.rb
@@ -34,7 +34,7 @@ class GlobalID
       def locate(gid, options = {})
         gid = GlobalID.parse(gid)
 
-        return unless gid && find_allowed?(gid.model_class, options[:only])
+        return unless gid && find_allowed?(gid, options[:only])
 
         locator = locator_for(gid)
 
@@ -70,7 +70,7 @@ class GlobalID
       def fetch(gid, options = {})
         gid = GlobalID.parse(gid)
 
-        return unless gid && find_allowed?(gid.model_class, options[:only])
+        return unless gid && find_allowed?(gid, options[:only])
 
         fetch_record(gid, options.except(:only)) or raise RecordNotFound, "Couldn't find record for #{gid}"
       end
@@ -180,8 +180,8 @@ class GlobalID
           @locators.fetch(normalize_app(gid.app)) { default_locator }
         end
 
-        def find_allowed?(model_class, only = nil)
-          only ? Array(only).any? { |c| model_class <= c } : true
+        def find_allowed?(gid, only = nil)
+          only ? Array(only).any? { |c| gid.model_class <= c } : true
         end
 
         def fetch_record(gid, options)
@@ -191,7 +191,7 @@ class GlobalID
         end
 
         def parse_allowed(gids, only = nil)
-          gids.collect { |gid| GlobalID.parse(gid) }.compact.select { |gid| find_allowed?(gid.model_class, only) }
+          gids.collect { |gid| GlobalID.parse(gid) }.compact.select { |gid| find_allowed?(gid, only) }
         end
 
         def normalize_app(app)


### PR DESCRIPTION
In the public api `GlobalID::Locator#locate` method, there is an
initial check to limit the global id's class to an allowlist of `only`
class list given as option.

The way it was implemented until now was that it we would **always**
try to constantize the model class from the global id even if no
`only:` option are provided.

This has the side effect to not be able to define a custom default
locator (which runs **after** that initial check) that would allow to
support “legacy” global ids containing legacy models (when refactoring
code / renaming class in a live application for example).

The implementation is straight forward: we now don't try to
constantize the class if we don't need it (moving that inside the
private `find_allowed?` method).