### PR TITLE
Add `GlobalID::Locator.fetch` with distinct not-found and unavailable errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ GlobalID::Locator.locate person_gid
 # => #<Person:0x007fae94bf6298 @id="1">
 ```
 
+`locate` returns `nil` for a blank or unparseable Global ID, and lets the
+backend's own exceptions bubble up when a record can't be found. Use `fetch`
+when you want to tell apart a record that's gone for good from a transient
+backend failure:
+
+```ruby
+GlobalID::Locator.fetch person_gid
+# => #<Person:0x007fae94bf6298 @id="1">           # found
+# => raises GlobalID::Locator::RecordNotFound     # the record no longer exists
+# => raises GlobalID::Locator::RecordUnavailable  # the backend failed; retry may succeed
+```
+
+Both errors extend `GlobalID::Locator::Error`, so you can rescue either at
+once. This is useful, for example, to discard a background job whose argument
+points at a deleted record, without also discarding jobs that hit a temporary
+database error.
+
 ### Signed Global IDs
 
 For added security GlobalIDs can also be signed to ensure that the data hasn't been tampered with.

--- a/lib/global_id/locator.rb
+++ b/lib/global_id/locator.rb
@@ -3,6 +3,17 @@ require 'active_support/core_ext/enumerable' # For Enumerable#index_by
 class GlobalID
   module Locator
     class InvalidModelIdError < StandardError; end
+    class Error < StandardError; end
+
+    # Raised by GlobalID::Locator.fetch when the GlobalID is valid but the
+    # record it references no longer exists. The record is gone for good, so
+    # retrying won't help.
+    class RecordNotFound < Error; end
+
+    # Raised by GlobalID::Locator.fetch when the record couldn't be located
+    # due to any other error in the backend, such as a database connection
+    # error. The record may still exist, so retrying may succeed.
+    class RecordUnavailable < Error; end
 
     class << self
       # The default locator used when no app-specific locator is found.
@@ -33,6 +44,35 @@ class GlobalID
         else
           locator.locate(gid, options.except(:only))
         end
+      end
+
+      # Like .locate, but instead of returning +nil+ or leaking the backend's
+      # own exceptions when the record can't be returned, it raises one of two
+      # GlobalID-specific errors so callers can tell the cases apart:
+      #
+      # * GlobalID::Locator::RecordNotFound when the record no longer exists.
+      #   Retrying won't help.
+      # * GlobalID::Locator::RecordUnavailable when the record couldn't be
+      #   located due to any other failure in the backend, like a database
+      #   connection error. The record may still exist, so retrying may succeed.
+      #
+      # The distinction is drawn without knowing the backend's exception
+      # classes: the record is looked up through a query that doesn't raise on
+      # missing records (like .locate_many's +:ignore_missing+), so an empty
+      # result means the record is gone, while an error from the query itself
+      # means the backend is unavailable.
+      #
+      # Returns +nil+ for a blank or unparseable GlobalID, or one disallowed by
+      # the +:only+ option, just like .locate, and accepts the same options.
+      #
+      # Note: custom locators registered with .use need to implement locate_many
+      # with support for the +:ignore_missing+ option for this method to work.
+      def fetch(gid, options = {})
+        gid = GlobalID.parse(gid)
+
+        return unless gid && find_allowed?(gid.model_class, options[:only])
+
+        fetch_record(gid, options.except(:only)) or raise RecordNotFound, "Couldn't find record for #{gid}"
       end
 
       # Takes an array of GlobalIDs or strings that can be turned into a GlobalIDs.
@@ -142,6 +182,12 @@ class GlobalID
 
         def find_allowed?(model_class, only = nil)
           only ? Array(only).any? { |c| model_class <= c } : true
+        end
+
+        def fetch_record(gid, options)
+          locator_for(gid).locate_many([gid], options.merge(ignore_missing: true)).first
+        rescue => error
+          raise RecordUnavailable, "Couldn't fetch record for #{gid}: #{error.message}"
         end
 
         def parse_allowed(gids, only = nil)

--- a/test/cases/global_locator_test.rb
+++ b/test/cases/global_locator_test.rb
@@ -82,6 +82,57 @@ class GlobalLocatorTest < ActiveSupport::TestCase
     end
   end
 
+  test '#fetch returns the record' do
+    found = GlobalID::Locator.fetch(@gid)
+    assert_kind_of @gid.model_class, found
+    assert_equal @gid.model_id, found.id
+  end
+
+  test '#fetch a composite primary key model' do
+    found = GlobalID::Locator.fetch(@cpk_gid)
+    assert_kind_of @cpk_gid.model_class, found
+    assert_equal ["tenant-key-value", "id-value"], found.id
+  end
+
+  test '#fetch by GID string' do
+    found = GlobalID::Locator.fetch(@gid.to_s)
+    assert_kind_of @gid.model_class, found
+    assert_equal @gid.model_id, found.id
+  end
+
+  test '#fetch with only: restriction with match' do
+    found = GlobalID::Locator.fetch(@gid, only: Person)
+    assert_kind_of @gid.model_class, found
+    assert_equal @gid.model_id, found.id
+  end
+
+  test '#fetch with only: restriction with no match returns nil' do
+    assert_nil GlobalID::Locator.fetch(@gid, only: String)
+  end
+
+  test '#fetch by non-GID returns nil' do
+    assert_nil GlobalID::Locator.fetch('This is not a GID')
+  end
+
+  test '#fetch raises RecordNotFound when the record no longer exists' do
+    gid = Person.new(Person::HARDCODED_ID_FOR_MISSING_PERSON).to_gid
+
+    error = assert_raises(GlobalID::Locator::RecordNotFound) do
+      GlobalID::Locator.fetch(gid)
+    end
+    assert_kind_of GlobalID::Locator::Error, error
+  end
+
+  test '#fetch raises RecordUnavailable when the backend fails' do
+    gid = Person.new(Person::HARDCODED_ID_FOR_FIND_ERROR).to_gid
+
+    error = assert_raises(GlobalID::Locator::RecordUnavailable) do
+      GlobalID::Locator.fetch(gid)
+    end
+
+    assert_kind_of GlobalID::Locator::Error, error
+  end
+
   test 'by many GIDs of one class' do
     assert_equal [ Person.new('1'), Person.new('2') ],
       GlobalID::Locator.locate_many([ Person.new('1').to_gid, Person.new('2').to_gid ])

--- a/test/models/composite_primary_key_model.rb
+++ b/test/models/composite_primary_key_model.rb
@@ -24,7 +24,7 @@ class CompositePrimaryKeyModel
     end
   end
 
-  def where(conditions)
+  def self.where(conditions)
     keys = conditions.keys
     raise "only primary key condition was expected" if keys.size != 1
     pk = keys.first

--- a/test/models/person.rb
+++ b/test/models/person.rb
@@ -2,6 +2,7 @@ class Person
   include GlobalID::Identification
 
   HARDCODED_ID_FOR_MISSING_PERSON = '1000'
+  HARDCODED_ID_FOR_FIND_ERROR = '2000'
 
   attr_reader :id
 
@@ -18,6 +19,8 @@ class Person
 
       if id == HARDCODED_ID_FOR_MISSING_PERSON
         raise 'Person missing'
+      elsif id == HARDCODED_ID_FOR_FIND_ERROR
+        raise 'A random error happened'
       else
         new(id)
       end
@@ -25,6 +28,10 @@ class Person
   end
 
   def self.where(conditions)
+    if conditions[primary_key].include? HARDCODED_ID_FOR_FIND_ERROR
+      raise 'A random error happened'
+    end
+
     (conditions[primary_key] - [HARDCODED_ID_FOR_MISSING_PERSON]).collect { |id| new(id) }
   end
 


### PR DESCRIPTION
This PR comes from https://github.com/rails/rails/pull/57742, from @byroot's suggestion [here](https://github.com/rails/rails/pull/57742#issuecomment-4727145369). 

 `GlobalID::Locator.locate` returns `nil` for a blank or unparseable GlobalID, but lets the backend's own exceptions bubble up when a record can't be found. Callers therefore can't tell apart a record that's gone for good from a transient backend failure (e.g. a database connection error) without knowing the backend's exception classes.

This PR introduces a new method, `.fetch`, that looks up the record via `locate_many` with `ignore_missing: true`, and raises these two new errors: 
- `GlobalID::Locator::RecordNotFound`, when the record is gone. 
- `GlobalID::Locator::RecordUnavailable`, for any other backend's error. 

This allows callers, such as Active Job, to discard a job whose argument points to a deleted record without also swallowing transient failures in which the record may still exist.