### PR TITLE
Document necessity of model defining `where` higher up in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ IDs, we have a universal identifier that works for objects of both classes.
 
 ## Usage
 
-Mix `GlobalID::Identification` into any model with a `#find(id)` class method.
-Support is automatically included in Active Record.
+Mix `GlobalID::Identification` into any model with a `.find(id)` class method that returns
+an instance of the model, and a `.where(id:)` class method that returns an enumerable of
+instance(s). Support is automatically included in Active Record.
 
 ```ruby
 person_gid = Person.find(1).to_global_id


### PR DESCRIPTION
Slight improvement to the readme based on the experience of overlooking it entirely.

[Rails edge recently changed how it uses Global ID](https://github.com/rails/rails/pull/57742), and that broke part of GoodJob that uses Global ID on a non Active Record object. I was very confused because I was like _What am I doing wrong with Global ID now?_ and it turns out I hadn't implemented `where` and I totally overlooked it lower down in the readme.

~~I dunno if my "if you use this part of Global ID you also need this interface" is better than simply saying "you gotta implement _both_ `find(id)` and `where(id: ids)` 🤷🏻~~ I rewrote it to say the interface is both methods.