### PR TITLE
Locate records from models that find but not where

### DIFF
--- a/lib/global_id/locator.rb
+++ b/lib/global_id/locator.rb
@@ -243,7 +243,7 @@ class GlobalID
           def find_records(model_class, ids, options)
             model_class = model_class.includes(options[:includes]) if options[:includes]
 
-            if options[:ignore_missing]
+            if options[:ignore_missing] && model_class.respond_to?(:where)
               model_class.where(primary_key(model_class) => ids)
             else
               model_class.find(ids)

--- a/test/cases/global_locator_test.rb
+++ b/test/cases/global_locator_test.rb
@@ -115,6 +115,37 @@ class GlobalLocatorTest < ActiveSupport::TestCase
     assert_nil GlobalID::Locator.fetch('This is not a GID')
   end
 
+  test '#locate_many a model without where' do
+    gids = [ PersonModel.new(id: '1').to_gid, PersonModel.new(id: '2').to_gid ]
+
+    found = GlobalID::Locator.locate_many(gids)
+    assert_equal %w[ 1 2 ], found.map(&:id)
+  end
+
+  test '#fetch a model without where' do
+    gid = PersonModel.new(id: '1').to_gid
+
+    found = GlobalID::Locator.fetch(gid)
+    assert_kind_of PersonModel, found
+    assert_equal '1', found.id
+  end
+
+  test '#fetch raises RecordNotFound when a model without where has no record' do
+    gid = PersonModel.new(id: PersonModel::MISSING_ID).to_gid
+
+    assert_raises(GlobalID::Locator::RecordNotFound) do
+      GlobalID::Locator.fetch(gid)
+    end
+  end
+
+  test '#fetch raises RecordUnavailable when a model without where fails' do
+    gid = PersonModel.new(id: PersonModel::ERROR_ID).to_gid
+
+    assert_raises(GlobalID::Locator::RecordUnavailable) do
+      GlobalID::Locator.fetch(gid)
+    end
+  end
+
   test '#fetch raises RecordNotFound when the record no longer exists' do
     gid = Person.new(Person::HARDCODED_ID_FOR_MISSING_PERSON).to_gid
 

--- a/test/models/person_model.rb
+++ b/test/models/person_model.rb
@@ -5,14 +5,25 @@ class PersonModel
   include ActiveModel::Model
   include GlobalID::Identification
 
+  MISSING_ID = '1000'
+  ERROR_ID = '2000'
+
   attr_accessor :id
 
   def self.primary_key
     :id
   end
 
-  def self.find(id)
-    new id: id
+  def self.find(id_or_ids)
+    if id_or_ids.is_a? Array
+      id_or_ids.filter_map { |id| find(id) }
+    else
+      case id_or_ids
+      when MISSING_ID then nil
+      when ERROR_ID then raise 'A random error happened'
+      else new id: id_or_ids
+      end
+    end
   end
 
   def ==(other)


### PR DESCRIPTION
Active Job moved from `.locate` to `.fetch` in rails/rails@52306a97 so that it could distinguish missing records from other errors.

`.fetch` indirectly calls `locate_many` with `ignore_missing: true`. This then calls `model_class.where(primary_key => ids)` so `.fetch` has an assumption that the `where` method is available.

`GlobalID::Identification` is documented as mixable into "any model with a `#find(id)` class method".

The example in those docs locates a model that has no `where`. That works for `locate` but calling `locate_many` doesn't:

```ruby
class Person
  include ActiveModel::Model
  include GlobalID::Identification

  attr_accessor :id

  def self.find(id)
    new id: id
  end
end

person = Person.new(id: '1')
GlobalID::Locator.locate(person.to_gid)
# => #<Person:0x00007fa0f3bcfc20 @id="1">

GlobalID::Locator.locate_many([ person.to_gid ])
# => NoMethodError: undefined method 'index_by' for an instance of Person

GlobalID::Locator.locate_many([ person.to_gid ], ignore_missing: true)
# => NoMethodError: undefined method 'where' for class Person

```

Fix by checking if `where` is available and if not falling back to calling `find` once per id as we can't assume that `find` takes an array, like Active Record does.

```ruby
GlobalID::Locator.locate_many([ person.to_gid ])
# => [#<Person:0x00007f9c931ce8a0 @id="1">]

GlobalID::Locator.locate_many([ person.to_gid ], ignore_missing: true)
# => [#<Person:0x00007f9c931cd770 @id="1">]
```

Checking for `respond_to?(:where)` as a proxy for whether a model is an Active Record one is not the nicest, but there are other places where we do similar checks already (e.g. `respond_to?(:primary_key)`).

A model that implements `where` but doesn't accept an `Array` for `find` works with `ignore_missing` set, but not if it isn't. This is an existing issue though.

An alternative approach would be to document that the `where` is required, but that's still going to be a breaking change in Active Job with the move to using `.fetch` there.

Another approach could be to remove any Active Record assumptions from globalid entirely and have Active Record register a custom handler for models inheriting from `ActiveRecord::Base`.